### PR TITLE
feat(publisher): expose publish_batch via pyo3, JSON get_entry, drop unwraps

### DIFF
--- a/crates/cli/publisher/src/commands/get_entry.rs
+++ b/crates/cli/publisher/src/commands/get_entry.rs
@@ -103,7 +103,7 @@ impl GetEntryCmd {
                 BTreeMap::new(),
             )
             .await
-            .unwrap();
+            .map_err(|e| anyhow::anyhow!("Failed to execute get_entry program: {}", e))?;
         println!("Here is the output stack: {:?}", output_stack);
         Ok(Entry {
             faucet_id: self.faucet_id.clone(),

--- a/crates/cli/publisher/src/commands/init.rs
+++ b/crates/cli/publisher/src/commands/init.rs
@@ -46,7 +46,10 @@ impl InitCmd {
         // if JsonStorage::exists(PRAGMA_ACCOUNTS_STORAGE) && JsonStorage::new(PRAGMA_ACCOUNTS_STORAGE).get_key(PUBLISHER_ACCOUNT_ID).is_some() {
         //     bail!("A Publisher has already been created! Delete it if you wanna start over.");
         // }
-        client.sync_state().await.unwrap();
+        client
+            .sync_state()
+            .await
+            .map_err(|e| anyhow::anyhow!("Could not sync state during init: {}", e))?;
 
         let (publisher_account, _) = PublisherAccountBuilder::new()
             .with_client(client)

--- a/crates/cli/publisher/src/commands/publish_batch.rs
+++ b/crates/cli/publisher/src/commands/publish_batch.rs
@@ -52,13 +52,7 @@ impl PublishBatchCmd {
         client: &mut Client<FilesystemKeyStore>,
         network: &str,
     ) -> anyhow::Result<()> {
-        let publisher_id = if let Some(id) = &self.publisher_id {
-            AccountId::from_hex(id)?
-        } else {
-            get_publisher_id(Path::new(PRAGMA_ACCOUNTS_STORAGE_FILE), network)?
-        };
-
-        let mut entries_data = Vec::new();
+        let mut typed_entries = Vec::with_capacity(self.entries.len());
         for entry_str in &self.entries {
             let parts: Vec<&str> = entry_str.split(':').collect();
             if parts.len() != 5 {
@@ -67,7 +61,6 @@ impl PublishBatchCmd {
                     entry_str
                 ));
             }
-
             let prefix = parts[0]
                 .parse::<u64>()
                 .map_err(|e| anyhow::anyhow!("Invalid faucet_id prefix '{}': {}", parts[0], e))?;
@@ -83,71 +76,109 @@ impl PublishBatchCmd {
             let timestamp = parts[4]
                 .parse::<u64>()
                 .map_err(|e| anyhow::anyhow!("Invalid timestamp '{}': {}", parts[4], e))?;
-
-            let faucet_id_word: Word = [
-                Felt::new(0),
-                Felt::new(0),
-                Felt::new(suffix),
-                Felt::new(prefix),
-            ].into();
-
-            let entry_word: Word = [
-                Felt::new(0),
-                Felt::new(price),
-                Felt::new(decimals as u64),
-                Felt::new(timestamp),
-            ].into();
-
-            let faucet_id_str = format!("{}:{}", prefix, suffix);
-            entries_data.push((faucet_id_str, faucet_id_word, entry_word));
+            typed_entries.push((format!("{}:{}", prefix, suffix), price, decimals, timestamp));
         }
+        publish_batch(client, network, &typed_entries, self.publisher_id.as_deref()).await
+    }
+}
 
-        let mut publish_calls = String::new();
-        for (_faucet_id_str, faucet_id_word, entry_word) in &entries_data {
-            publish_calls.push_str(&format!(
-                "
-                    push.{entry}
-                    push.{faucet_id_word}
-                    call.publisher_module::publish_entry
-                    dropw
-                ",
-                faucet_id_word = word_to_masm(*faucet_id_word),
-                entry = word_to_masm(*entry_word)
+/// Publish a batch of price entries in a single Miden transaction.
+///
+/// Each entry is `(faucet_id, price, decimals, timestamp)` where `faucet_id`
+/// is `"PREFIX:SUFFIX"` (e.g. `"1:0"` for BTC/USD).
+///
+/// Exposed as a free function so it can be called directly by other crates
+/// (notably the pyo3 binding) without having to round-trip through the
+/// CLI's string format.
+pub async fn publish_batch(
+    client: &mut Client<FilesystemKeyStore>,
+    network: &str,
+    entries: &[(String, u64, u32, u64)],
+    publisher_id_override: Option<&str>,
+) -> anyhow::Result<()> {
+    let publisher_id = if let Some(id) = publisher_id_override {
+        AccountId::from_hex(id)?
+    } else {
+        get_publisher_id(Path::new(PRAGMA_ACCOUNTS_STORAGE_FILE), network)?
+    };
+
+    let mut entries_data = Vec::with_capacity(entries.len());
+    for (faucet_id, price, decimals, timestamp) in entries {
+        let parts: Vec<&str> = faucet_id.split(':').collect();
+        if parts.len() != 2 {
+            return Err(anyhow::anyhow!(
+                "Invalid faucet_id format '{}'. Expected PREFIX:SUFFIX (e.g., 1:0)",
+                faucet_id
             ));
         }
+        let prefix = parts[0]
+            .parse::<u64>()
+            .map_err(|e| anyhow::anyhow!("Invalid faucet_id prefix '{}': {}", parts[0], e))?;
+        let suffix = parts[1]
+            .parse::<u64>()
+            .map_err(|e| anyhow::anyhow!("Invalid faucet_id suffix '{}': {}", parts[1], e))?;
 
-        let tx_script_code = format!(
-            "
-                use publisher_component::publisher_module
-                use miden::core::sys
-        
-                begin
-                    {publish_calls}
-                    exec.sys::truncate_stack                    
-                end
-            ",
-            publish_calls = publish_calls
-        );
-
-        let publisher_lib = get_publisher_component_library();
-        let publish_script = CodeBuilder::default()
-            .with_statically_linked_library(&publisher_lib)
-            .map_err(|e| anyhow::anyhow!("Error while setting up the component library: {e:?}"))?
-            .compile_tx_script(tx_script_code)
-            .map_err(|e| anyhow::anyhow!("Error while compiling the script: {e:?}"))?;
-
-        let transaction_request = TransactionRequestBuilder::new()
-            .custom_script(publish_script)
-            .build()
-            .map_err(|e| anyhow::anyhow!("Error while building transaction request: {e:?}"))?;
-
-        client
-            .submit_new_transaction(publisher_id, transaction_request)
-            .await
-            .map_err(|e| anyhow::anyhow!("Error while submitting transaction: {e:?}"))?;
-
-        println!("✓ Batch publish successful! ({} entries)", entries_data.len());
-
-        Ok(())
+        let faucet_id_word: Word = [
+            Felt::new(0),
+            Felt::new(0),
+            Felt::new(suffix),
+            Felt::new(prefix),
+        ]
+        .into();
+        let entry_word: Word = [
+            Felt::new(0),
+            Felt::new(*price),
+            Felt::new(*decimals as u64),
+            Felt::new(*timestamp),
+        ]
+        .into();
+        entries_data.push((faucet_id_word, entry_word));
     }
+
+    let mut publish_calls = String::new();
+    for (faucet_id_word, entry_word) in &entries_data {
+        publish_calls.push_str(&format!(
+            "
+                push.{entry}
+                push.{faucet_id_word}
+                call.publisher_module::publish_entry
+                dropw
+            ",
+            faucet_id_word = word_to_masm(*faucet_id_word),
+            entry = word_to_masm(*entry_word)
+        ));
+    }
+
+    let tx_script_code = format!(
+        "
+            use publisher_component::publisher_module
+            use miden::core::sys
+
+            begin
+                {publish_calls}
+                exec.sys::truncate_stack
+            end
+        ",
+        publish_calls = publish_calls
+    );
+
+    let publisher_lib = get_publisher_component_library();
+    let publish_script = CodeBuilder::default()
+        .with_statically_linked_library(&publisher_lib)
+        .map_err(|e| anyhow::anyhow!("Error while setting up the component library: {e:?}"))?
+        .compile_tx_script(tx_script_code)
+        .map_err(|e| anyhow::anyhow!("Error while compiling the script: {e:?}"))?;
+
+    let transaction_request = TransactionRequestBuilder::new()
+        .custom_script(publish_script)
+        .build()
+        .map_err(|e| anyhow::anyhow!("Error while building transaction request: {e:?}"))?;
+
+    client
+        .submit_new_transaction(publisher_id, transaction_request)
+        .await
+        .map_err(|e| anyhow::anyhow!("Error while submitting transaction: {e:?}"))?;
+
+    println!("✓ Batch publish successful! ({} entries)", entries_data.len());
+    Ok(())
 }

--- a/crates/cli/publisher/src/lib.rs
+++ b/crates/cli/publisher/src/lib.rs
@@ -4,7 +4,8 @@ use pyo3::prelude::*;
 use std::path::PathBuf;
 mod commands;
 use crate::commands::{
-    entry::EntryCmd, get_entry::GetEntryCmd, init::InitCmd, publish::PublishCmd, sync::SyncCmd,
+    entry::EntryCmd, get_entry::GetEntryCmd, init::InitCmd, publish::PublishCmd,
+    publish_batch::publish_batch as do_publish_batch, sync::SyncCmd,
 };
 use pm_utils_cli::{setup_devnet_client, setup_local_client, setup_testnet_client, STORE_FILENAME};
 
@@ -79,7 +80,8 @@ fn py_publish(
     })
 }
 
-/// Get entry
+/// Get entry. Returns the entry serialized as a JSON string:
+/// `{"faucet_id": "1:0", "price": 6819900000000, "decimals": 8, "timestamp": 1700000000}`.
 #[pyfunction]
 #[pyo3(name = "get_entry")]
 fn py_get_entry(
@@ -99,11 +101,18 @@ fn py_get_entry(
         let mut client = setup_client(network_str, store_config, keystore_path).await?;
 
         let cmd = GetEntryCmd { faucet_id };
-        cmd.call(&mut client, network_str)
+        let entry = cmd
+            .call(&mut client, network_str)
             .await
             .map_err(|e| PyValueError::new_err(format!("Get entry failed: {}", e)))?;
 
-        Ok("Entry retrieved successfully!".to_string())
+        Ok(serde_json::json!({
+            "faucet_id": entry.faucet_id,
+            "price": entry.price,
+            "decimals": entry.decimals,
+            "timestamp": entry.timestamp,
+        })
+        .to_string())
     })
 }
 
@@ -132,6 +141,37 @@ fn py_entry(
             .map_err(|e| PyValueError::new_err(format!("Entry failed: {}", e)))?;
 
         Ok("Entry details retrieved successfully!".to_string())
+    })
+}
+
+/// Publish a batch of price entries in a single Miden transaction.
+///
+/// `entries` is a list of `(faucet_id, price, decimals, timestamp)` tuples,
+/// where `faucet_id` is the `"PREFIX:SUFFIX"` string (e.g. `"1:0"`).
+#[pyfunction]
+#[pyo3(name = "publish_batch")]
+fn py_publish_batch(
+    entries: Vec<(String, u64, u32, u64)>,
+    storage_path: Option<String>,
+    keystore_path: Option<String>,
+    network: Option<String>,
+) -> PyResult<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| PyValueError::new_err(format!("Failed to create async runtime: {}", e)))?;
+
+    rt.block_on(async {
+        let store_config = get_store_config(storage_path);
+        let network_str = network.as_deref().unwrap_or("testnet");
+        let mut client = setup_client(network_str, store_config, keystore_path).await?;
+
+        do_publish_batch(&mut client, network_str, &entries, None)
+            .await
+            .map_err(|e| PyValueError::new_err(format!("Publish batch failed: {}", e)))?;
+
+        Ok(())
     })
 }
 
@@ -168,6 +208,7 @@ fn py_sync(
 fn pm_publisher(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(py_init))?;
     m.add_wrapped(wrap_pyfunction!(py_publish))?;
+    m.add_wrapped(wrap_pyfunction!(py_publish_batch))?;
     m.add_wrapped(wrap_pyfunction!(py_get_entry))?;
     m.add_wrapped(wrap_pyfunction!(py_entry))?;
     m.add_wrapped(wrap_pyfunction!(py_sync))?;


### PR DESCRIPTION
## Summary

Three improvements to the `pm-publisher-cli` Python bindings, driven by the
`pragma-sdk` Miden integration work on the `feat-miden-integration` branch.

- **New `pm_publisher.publish_batch(entries, ...)`** — lets the SDK send N
  price entries in a single Miden transaction instead of N sequential ones.
  In the price-pusher, this turns a per-tick "publish 7 pairs" cost from
  ~7×Miden-tx-latency down to a single tx, which directly improves the
  isolation guarantee (a slow Miden node no longer keeps the Python event
  loop offloaded for several seconds × N).
- **`pm_publisher.get_entry` now returns JSON** instead of the constant
  string `"Entry retrieved successfully!"` — the Rust `GetEntryCmd::call`
  already returned a full `Entry`, the binding was just discarding it.
  Shape: `{"faucet_id": "1:0", "price": <u64>, "decimals": <u32>, "timestamp": <u64>}`.
- **Drop two `.unwrap()`s on the hot path** — `sync_state()` in `init` and
  `execute_program()` in `get_entry` now return clean errors instead of
  panicking on a network blip.

## Implementation notes

- `publish_batch` logic was extracted from `PublishBatchCmd::call` into a
  free `pub async fn publish_batch(...)` so the pyo3 binding can call it
  directly with typed `(faucet_id, price, decimals, timestamp)` tuples
  without round-tripping through the CLI's `"prefix:suffix:price:decimals:timestamp"`
  string format. The CLI command still works exactly as before — it parses
  its strings and delegates to the same function.
- No existing public surface changed beyond `py_get_entry`'s return value
  (which was unusable before — a fixed string regardless of input).

## Test plan

- [x] `cargo build` (workspace) — clean
- [x] `cargo build -p pm-publisher-cli` (cdylib) — clean
- [x] `cargo build --bin pm-publisher-cli` — clean
- [ ] Manual: rebuild the `pm-publisher` wheel, install in pragma-sdk,
      verify `pm_publisher.publish_batch([...])` and
      `pm_publisher.get_entry(...)` against a testnet publisher

🤖 Generated with [Claude Code](https://claude.com/claude-code)