### PR TITLE
feat(publisher): expose import_account via pyo3 + bump to 0.1.0-alpha.3

### DIFF
--- a/crates/cli/publisher/pyproject.toml
+++ b/crates/cli/publisher/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pm-publisher"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 description = "Python bindings for Pragma Miden Publisher CLI"
 authors = [{ name = "Pragma", email = "jordy@pragma.build" }]
 requires-python = ">=3.7"

--- a/crates/cli/publisher/src/lib.rs
+++ b/crates/cli/publisher/src/lib.rs
@@ -1,3 +1,4 @@
+use miden_client::account::AccountId;
 use miden_client::{keystore::FilesystemKeyStore, Client};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -175,6 +176,39 @@ fn py_publish_batch(
     })
 }
 
+/// Import an existing on-chain public account (oracle or publisher) into the
+/// local store so its state is tracked across restarts. This is required when
+/// the local SQLite store has been wiped (e.g. ephemeral pod storage in K8s)
+/// but the account itself still lives on-chain. Idempotent — a second call
+/// for an already-tracked account just re-fetches and updates state.
+#[pyfunction]
+#[pyo3(name = "import_account")]
+fn py_import_account(
+    account_id: String,
+    storage_path: Option<String>,
+    keystore_path: Option<String>,
+    network: Option<String>,
+) -> PyResult<()> {
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| PyValueError::new_err(format!("Failed to create async runtime: {}", e)))?;
+
+    rt.block_on(async {
+        let store_config = get_store_config(storage_path);
+        let network_str = network.as_deref().unwrap_or("testnet");
+        let mut client = setup_client(network_str, store_config, keystore_path).await?;
+
+        let id = AccountId::from_hex(&account_id)
+            .map_err(|e| PyValueError::new_err(format!("Invalid account_id '{}': {}", account_id, e)))?;
+
+        client
+            .import_account_by_id(id)
+            .await
+            .map_err(|e| PyValueError::new_err(format!("Import account failed: {}", e)))?;
+
+        Ok(())
+    })
+}
+
 /// Sync state
 #[pyfunction]
 #[pyo3(name = "sync")]
@@ -212,6 +246,7 @@ fn pm_publisher(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(py_get_entry))?;
     m.add_wrapped(wrap_pyfunction!(py_entry))?;
     m.add_wrapped(wrap_pyfunction!(py_sync))?;
+    m.add_wrapped(wrap_pyfunction!(py_import_account))?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Adds \`pm_publisher.import_account(account_id, storage_path?, keystore_path?, network?)\` which wraps \`Client::import_account_by_id\`. Lets clients re-attach an existing on-chain public account (oracle or publisher) to a freshly-initialized local SQLite store.

Bumps the wheel version to \`0.1.0-alpha.3\` for PyPI release. Once merged → tag \`py-v0.1.3\` → CI publishes.

## Problem this solves (concrete prod symptom)

The pragma-sdk price-pusher in K8s runs with the Miden store on an emptyDir, wiped on every pod restart. After restart:

\`\`\`
INFO:pragma_sdk.client:Miden publisher reused from config (network=testnet, id=0x2f3aa66d...)
🌐 Miden publishing enabled
🔁 Sync successful! State synced to block 586562
   Tracked accounts updated: 0   ← nothing tracked, sync was a no-op for our account
ERROR: Publish batch failed: Error while submitting transaction:
       AccountDataNotFound(V0(AccountIdV0 { suffix: ..., prefix: ... }))   ← our publisher
\`\`\`

\`sync_state\` alone won't fix this — it only refreshes accounts already in the tracked set. \`import_account_by_id\` fetches the account from the network and adds it.

## SDK plan

Once a wheel \`pm-publisher==0.1.0a3\` is on PyPI, \`pragma-sdk\` will call \`import_account\` once at startup right after \`sync\`, so the tracked set gets seeded before the first \`publish_batch\`. Tracked in [pragma-sdk] follow-up.

## Test plan

- [x] \`cargo build -p pm-publisher-cli\` clean
- [ ] Wheel published on tag push
- [ ] SDK 2.13.0a4 wires it up and confirms in prod that \`Tracked accounts updated: 1\` after import + sync, and \`🌐 MIDEN: published 5/5 entries\` follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)