### PR TITLE
fix(pyo3): reuse a single Tokio runtime across all bindings (closes #44)

### DIFF
--- a/crates/cli/publisher/pyproject.toml
+++ b/crates/cli/publisher/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pm-publisher"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 description = "Python bindings for Pragma Miden Publisher CLI"
 authors = [{ name = "Pragma", email = "jordy@pragma.build" }]
 requires-python = ">=3.7"

--- a/crates/cli/publisher/src/lib.rs
+++ b/crates/cli/publisher/src/lib.rs
@@ -3,12 +3,34 @@ use miden_client::{keystore::FilesystemKeyStore, Client};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use std::path::PathBuf;
+use std::sync::OnceLock;
+use tokio::runtime::{Builder, Runtime};
 mod commands;
 use crate::commands::{
     entry::EntryCmd, get_entry::GetEntryCmd, init::InitCmd, publish::PublishCmd,
     publish_batch::publish_batch as do_publish_batch, sync::SyncCmd,
 };
 use pm_utils_cli::{setup_devnet_client, setup_local_client, setup_testnet_client, STORE_FILENAME};
+
+/// Single shared Tokio runtime for the lifetime of the Python process.
+/// Creating one runtime per pyo3 call (the previous behaviour) was
+/// allocating ~200-400Mi RSS each tick, which crashed long-running
+/// embedders like the pragma-sdk price-pusher with OOMKilled.
+static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+
+fn rt() -> &'static Runtime {
+    RUNTIME.get_or_init(|| {
+        // 2 worker threads is enough for the bindings' workload (one
+        // gRPC call + a tx submit). Avoid the default `num_cpus` which
+        // would be wasteful in a price-pusher pod.
+        Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .thread_name("pm-publisher")
+            .build()
+            .expect("failed to build pm-publisher Tokio runtime")
+    })
+}
 
 
 /// Initialize publisher and return a client handle
@@ -20,10 +42,7 @@ fn py_init(
     keystore_path: Option<String>,
     network: Option<String>,
 ) -> PyResult<()> {
-    let rt = tokio::runtime::Runtime::new()
-        .map_err(|e| PyValueError::new_err(format!("Failed to create async runtime: {}", e)))?;
-
-    rt.block_on(async {
+    rt().block_on(async {
         // Convert storage_path to PathBuf, default to current dir if None
         let store_config = get_store_config(storage_path);
 
@@ -55,9 +74,7 @@ fn py_publish(
     keystore_path: Option<String>,
     network: Option<String>,
 ) -> PyResult<()> {
-    let rt = tokio::runtime::Runtime::new()
-        .map_err(|e| PyValueError::new_err(format!("Failed to create async runtime: {}", e)))?;
-    rt.block_on(async {
+    rt().block_on(async {
         // Create client inside the function like the other functions
         let store_config = get_store_config(storage_path);
 
@@ -91,10 +108,7 @@ fn py_get_entry(
     keystore_path: Option<String>,
     network: Option<String>,
 ) -> PyResult<String> {
-    let rt = tokio::runtime::Runtime::new()
-        .map_err(|e| PyValueError::new_err(format!("Failed to create async runtime: {}", e)))?;
-
-    rt.block_on(async {
+    rt().block_on(async {
         let store_config = get_store_config(storage_path);
 
         let network_str = network.as_deref().unwrap_or("testnet");
@@ -126,10 +140,7 @@ fn py_entry(
     keystore_path: Option<String>,
     network: Option<String>,
 ) -> PyResult<String> {
-    let rt = tokio::runtime::Runtime::new()
-        .map_err(|e| PyValueError::new_err(format!("Failed to create async runtime: {}", e)))?;
-
-    rt.block_on(async {
+    rt().block_on(async {
         let store_config = get_store_config(storage_path);
 
         let network_str = network.as_deref().unwrap_or("testnet");
@@ -160,10 +171,7 @@ fn py_publish_batch(
     if entries.is_empty() {
         return Ok(());
     }
-    let rt = tokio::runtime::Runtime::new()
-        .map_err(|e| PyValueError::new_err(format!("Failed to create async runtime: {}", e)))?;
-
-    rt.block_on(async {
+    rt().block_on(async {
         let store_config = get_store_config(storage_path);
         let network_str = network.as_deref().unwrap_or("testnet");
         let mut client = setup_client(network_str, store_config, keystore_path).await?;
@@ -189,10 +197,7 @@ fn py_import_account(
     keystore_path: Option<String>,
     network: Option<String>,
 ) -> PyResult<()> {
-    let rt = tokio::runtime::Runtime::new()
-        .map_err(|e| PyValueError::new_err(format!("Failed to create async runtime: {}", e)))?;
-
-    rt.block_on(async {
+    rt().block_on(async {
         let store_config = get_store_config(storage_path);
         let network_str = network.as_deref().unwrap_or("testnet");
         let mut client = setup_client(network_str, store_config, keystore_path).await?;
@@ -217,10 +222,7 @@ fn py_sync(
     keystore_path: Option<String>,
     network: Option<String>,
 ) -> PyResult<String> {
-    let rt = tokio::runtime::Runtime::new()
-        .map_err(|e| PyValueError::new_err(format!("Failed to create async runtime: {}", e)))?;
-
-    rt.block_on(async {
+    rt().block_on(async {
         let store_config = get_store_config(storage_path);
 
         let network_str = network.as_deref().unwrap_or("testnet");


### PR DESCRIPTION
Closes #44.

Each pyo3 binding was creating a fresh \`tokio::runtime::Runtime::new()\`, running one \`block_on\`, and dropping it. RSS grew on every call because the Rust allocator doesn't always return freed memory to the OS. This reproducibly OOM-killed the pragma-sdk price-pusher in prod, even after bumping its memory limit from 600Mi to 1.5Gi.

## Fix

A process-wide \`OnceLock<Runtime>\` initialized on first use, with 2 worker threads (default \`num_cpus\` was wasteful for a one-call-at-a-time workload):

\`\`\`rust
static RUNTIME: OnceLock<Runtime> = OnceLock::new();

fn rt() -> &'static Runtime {
    RUNTIME.get_or_init(|| {
        Builder::new_multi_thread()
            .worker_threads(2)
            .enable_all()
            .thread_name(\"pm-publisher\")
            .build()
            .expect(\"...\")
    })
}
\`\`\`

All 7 bindings (\`init\`, \`publish\`, \`publish_batch\`, \`get_entry\`, \`entry\`, \`sync\`, \`import_account\`) call \`rt().block_on(...)\`.

## Expected impact

Steady-state RSS for the price-pusher should drop from ~1.4Gi (and growing) to ~600-700Mi flat after a 10-minute soak. Will validate in prod after pragma-sdk picks up the new wheel.

## Wheel bump

\`crates/cli/publisher/pyproject.toml\` bumped to \`0.1.0-alpha.4\`. After merge → \`py-v0.1.4\` tag → CI publishes \`pm-publisher==0.1.0a4\`.

## Test plan

- [x] \`cargo build -p pm-publisher-cli\` clean
- [ ] Once wheel published, pragma-sdk pins \`pm-publisher>=0.1.0a4\` and ships v2.13.0a5
- [ ] Soak in prod for 30 min, watch \`kubectl top pod\` to verify RSS stays flat

🤖 Generated with [Claude Code](https://claude.com/claude-code)