### PR TITLE
fix(accounts): cache assembled publisher/oracle libraries in OnceLock

### DIFF
--- a/crates/accounts/src/oracle/mod.rs
+++ b/crates/accounts/src/oracle/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use rand::Rng;
 
@@ -42,19 +42,27 @@ pub fn oracle_storage_slots() -> Vec<StorageSlot> {
     ]
 }
 
+/// Process-wide cache for the assembled oracle library. See the publisher
+/// version for rationale.
+static ORACLE_LIB: OnceLock<Arc<Library>> = OnceLock::new();
+
 pub fn get_oracle_component_library() -> Arc<Library> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let oracle_masm = get_oracle_masm();
-    let oracle_component_module = Module::parser(ModuleKind::Library)
-        .parse_str(
-            LibraryPath::new("oracle_component::oracle_module"),
-            &oracle_masm,
-            source_manager.clone(),
-        )
-        .unwrap();
-    TransactionKernel::assembler_with_source_manager(source_manager)
-        .assemble_library([oracle_component_module])
-        .expect("assembly should succeed")
+    ORACLE_LIB
+        .get_or_init(|| {
+            let source_manager = Arc::new(DefaultSourceManager::default());
+            let oracle_masm = get_oracle_masm();
+            let oracle_component_module = Module::parser(ModuleKind::Library)
+                .parse_str(
+                    LibraryPath::new("oracle_component::oracle_module"),
+                    &oracle_masm,
+                    source_manager.clone(),
+                )
+                .unwrap();
+            TransactionKernel::assembler_with_source_manager(source_manager)
+                .assemble_library([oracle_component_module])
+                .expect("assembly should succeed")
+        })
+        .clone()
 }
 
 pub fn get_median_procedure_hash() -> String {

--- a/crates/accounts/src/publisher/mod.rs
+++ b/crates/accounts/src/publisher/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use rand::Rng;
 
@@ -52,19 +52,32 @@ pub fn get_entry_procedure_hash() -> String {
         .join(".")
 }
 
-pub fn get_publisher_component_library() -> Arc<Library> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let publisher_component_module = Module::parser(ModuleKind::Library)
-        .parse_str(
-            LibraryPath::new("publisher_component::publisher_module"),
-            PUBLISHER_ACCOUNT_MASM,
-            source_manager.clone(),
-        )
-        .unwrap();
+/// Process-wide cache for the assembled publisher library.
+///
+/// The MASM parse + assemble step is expensive (allocates the full AST,
+/// then assembles into MAST). Doing it on every call was causing
+/// multi-hundred-Mb transient RSS spikes that OOM-killed long-running
+/// embedders like the pragma-sdk price-pusher in K8s. The library never
+/// changes for the lifetime of the process, so we assemble once.
+static PUBLISHER_LIB: OnceLock<Arc<Library>> = OnceLock::new();
 
-    TransactionKernel::assembler_with_source_manager(source_manager)
-        .assemble_library([publisher_component_module])
-        .expect("assembly should succeed")
+pub fn get_publisher_component_library() -> Arc<Library> {
+    PUBLISHER_LIB
+        .get_or_init(|| {
+            let source_manager = Arc::new(DefaultSourceManager::default());
+            let publisher_component_module = Module::parser(ModuleKind::Library)
+                .parse_str(
+                    LibraryPath::new("publisher_component::publisher_module"),
+                    PUBLISHER_ACCOUNT_MASM,
+                    source_manager.clone(),
+                )
+                .unwrap();
+
+            TransactionKernel::assembler_with_source_manager(source_manager)
+                .assemble_library([publisher_component_module])
+                .expect("assembly should succeed")
+        })
+        .clone()
 }
 
 pub fn get_publisher_component() -> AccountComponent {

--- a/crates/cli/publisher/pyproject.toml
+++ b/crates/cli/publisher/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pm-publisher"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 description = "Python bindings for Pragma Miden Publisher CLI"
 authors = [{ name = "Pragma", email = "jordy@pragma.build" }]
 requires-python = ">=3.7"


### PR DESCRIPTION
## Issue

Even with the Tokio runtime singleton from #45 / pm-publisher 0.1.0a4, the pragma-sdk price-pusher pod kept OOM-killing on every \`publish_batch\` attempt, despite:
- Steady-state RSS at **118Mi**
- 1.5Gi memory limit
- 1 single shared Tokio runtime

So this wasn't a leak — it was a **transient RSS spike** during the publish call itself, blowing past 1.5Gi before snapping back.

## Root cause

\`get_publisher_component_library()\` and \`get_oracle_component_library()\` re-run the full MASM parse + \`assemble_library\` pipeline on every call:

\`\`\`rust
pub fn get_publisher_component_library() -> Arc<Library> {
    let source_manager = Arc::new(DefaultSourceManager::default());
    let publisher_component_module = Module::parser(ModuleKind::Library)
        .parse_str(...)
        .unwrap();
    TransactionKernel::assembler_with_source_manager(source_manager)
        .assemble_library([publisher_component_module])
        .expect(\"assembly should succeed\")
}
\`\`\`

\`assemble_library\` builds the full MAST (Merkle Abstract Syntax Tree) — that's the spike.

In the price-pusher path, this gets called from \`publish_batch\` every tick, and (in v2.13.0a4+) also from \`import_account\` + \`sync\` at startup, multiplying the peak.

## Fix

Wrap each library getter in a process-wide \`OnceLock<Arc<Library>>\`:

\`\`\`rust
static PUBLISHER_LIB: OnceLock<Arc<Library>> = OnceLock::new();

pub fn get_publisher_component_library() -> Arc<Library> {
    PUBLISHER_LIB
        .get_or_init(|| { /* parse + assemble exactly once */ })
        .clone()  // cheap Arc bump
}
\`\`\`

Same pattern for oracle. The MASM is \`include_str!(...)\` so it's a static constant and the assembled library never changes during a process lifetime.

The \`get_publisher_component()\` / \`get_oracle_component()\` functions (called at account creation only) still need a \`(*arc).clone()\` because they consume the \`Library\` by value — that's fine, account creation happens once per env, not per tick.

## Wheel bump

\`crates/cli/publisher/pyproject.toml\` bumped to \`0.1.0-alpha.5\`. After merge → \`py-v0.1.5\` tag → CI publishes \`pm-publisher==0.1.0a5\`.

## Test plan

- [x] \`cargo build -p pm-accounts -p pm-publisher-cli\` clean
- [ ] Wheel published, pragma-sdk pins \`pm-publisher>=0.1.0a5\`, ships v2.13.0a6
- [ ] Soak in prod: \`kubectl top pod\` should show no spikes above ~300Mi during a publish_batch (vs >1.5Gi today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)