### PR TITLE
feat(oracle-explorer): allow pragma_miden.json override via mounted secret

### DIFF
--- a/entrypoint-init.sh
+++ b/entrypoint-init.sh
@@ -7,8 +7,16 @@ WORKSPACE="${ORACLE_WORKSPACE_PATH:-/data/oracle-workspace}"
 mkdir -p "${WORKSPACE}/keystore"
 mkdir -p "${WORKSPACE}/miden_storage"
 
-# Copy embedded pragma_miden.json
-cp /app/pragma_miden.json "${WORKSPACE}/pragma_miden.json"
+# Prefer a config mounted from a K8s secret at /secrets/config/pragma_miden.json
+# (used by deployments that point this image at a custom oracle), otherwise
+# fall back to the one baked into the image.
+if [ -f /secrets/config/pragma_miden.json ]; then
+  cp /secrets/config/pragma_miden.json "${WORKSPACE}/pragma_miden.json"
+  echo "Using pragma_miden.json from mounted secret"
+else
+  cp /app/pragma_miden.json "${WORKSPACE}/pragma_miden.json"
+  echo "Using pragma_miden.json baked into image"
+fi
 
 # Copy keystore files from mounted secrets
 for f in /secrets/keystore/*; do

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -53,6 +53,12 @@ spec:
               subPath: keystore
               readOnly: true
             {{- end }}
+            {{- if .Values.configSecret }}
+            - name: config-secret
+              mountPath: /secrets/config/pragma_miden.json
+              subPath: config
+              readOnly: true
+            {{- end }}
       containers:
         - name: {{ include "oracle-explorer.fullname" . }}
           securityContext:
@@ -115,4 +121,9 @@ spec:
         - name: keystore-{{ .fileName }}
           secret:
             secretName: {{ .secretName }}
+        {{- end }}
+        {{- if .Values.configSecret }}
+        - name: config-secret
+          secret:
+            secretName: {{ .configSecret.secretName }}
         {{- end }}

--- a/helm/templates/externalSecret.yaml
+++ b/helm/templates/externalSecret.yaml
@@ -64,3 +64,25 @@ spec:
     gcpsm:
       projectID: prod-pragma
 {{- end }}
+
+{{- if .Values.configSecret }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.configSecret.secretName }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  refreshInterval: "24h"
+  secretStoreRef:
+    name: oracle-explorer-keystore-store
+    kind: SecretStore
+  target:
+    name: {{ .Values.configSecret.secretName }}
+  data:
+    - secretKey: config
+      remoteRef:
+        key: {{ .Values.configSecret.secretName }}
+        decodingStrategy: None
+{{- end }}


### PR DESCRIPTION
Lets deployments point the oracle-explorer image at a private oracle without rebuilding the image.

## Changes

- `entrypoint-init.sh` prefers `/secrets/config/pragma_miden.json` when present, falls back to `/app/pragma_miden.json` baked at build time.
- Helm chart gains an optional `configSecret: { secretName }` value:
  - When set, an `ExternalSecret` pulls the GCP secret and mounts it at `/secrets/config/pragma_miden.json`
  - When unset, behaviour is unchanged

Backwards compatible.

## Use case

The pragma-sdk Miden integration runs against a Pragma-owned testnet oracle (`0xd0e1384e21a6350029d80128eb5c44`) that's distinct from the public demo oracle baked into this repo. Devops will set `configSecret.secretName: miden-oracle-config-pragma` and the explorer will display our oracle's prices instead of the demo's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)