### PR TITLE
fix(helm): use .Values.configSecret.secretName (scope was wrong)

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -125,5 +125,5 @@ spec:
         {{- if .Values.configSecret }}
         - name: config-secret
           secret:
-            secretName: {{ .configSecret.secretName }}
+            secretName: {{ .Values.configSecret.secretName }}
         {{- end }}


### PR DESCRIPTION
PR #47 introduced `secretName: {{ .configSecret.secretName }}` inside an `{{ if .Values.configSecret }}` block.

`{{ if }}` does NOT change scope (unlike `with`), so `.` stays at the root and `.configSecret.secretName` resolved to `nil`. ArgoCD's manifest generation in prod failed with:

```
nil pointer evaluating interface {}.secretName
```

One-line fix: use the fully-qualified path `.Values.configSecret.secretName`. Validated locally with `helm template` against the devops values, the manifest now includes the config-secret volume and ExternalSecret as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)