### PR TITLE
fix(docker): install ca-certificates in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN pnpm build
 # ── Stage 3: Runtime ──────────────────────────────────────────────────────────
 FROM node:20-slim AS runner
 
-RUN apt-get update && apt-get install -y libsqlite3-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libsqlite3-dev ca-certificates && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
Prod symptom on miden.pragma.build /api/prices:

```
Error: RPC error
Caused by:
    0: failed to connect to the Miden node
    1: transport error
    2: no native certs found
```

The pm-oracle-cli binary uses rustls (via rustls-native-certs) to verify the TLS cert of the Miden testnet gRPC endpoint. It looks for `/etc/ssl/certs/ca-certificates.crt` — which isn't shipped on `node:20-slim` by default.

One-liner: `apt-get install -y ca-certificates` in the runtime stage.

Touches `Dockerfile` so the docker-build workflow will trigger automatically on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)