### PR TITLE
fix(oracle-cli): import oracle account in median-batch (parity with median)

### DIFF
--- a/crates/cli/oracle/src/commands/median_batch.rs
+++ b/crates/cli/oracle/src/commands/median_batch.rs
@@ -68,6 +68,10 @@ impl MedianBatchCmd {
         // STEP 1: Setup - done ONCE for all pairs
         let oracle_id = get_oracle_id(Path::new(PRAGMA_ACCOUNTS_STORAGE_FILE), network)?;
 
+        // Re-import oracle from chain to get fresh storage state. sync_state
+        // only refreshes accounts already in the tracked set, so on a fresh
+        // store (e.g. emptyDir K8s deployments) we need to import first.
+        client.import_account_by_id(oracle_id).await?;
         client.sync_state().await?;
         let account = client
             .get_account(oracle_id)


### PR DESCRIPTION
Single-pair `median` calls `import_account_by_id` before `get_account`, but `median-batch` only calls `sync_state` — which only refreshes accounts already tracked.

On a fresh local store (e.g. K8s emptyDir), the oracle isn't tracked so `get_account` returns None:

```
Error: Oracle account not found. Make sure you run this command from the oracle workspace directory ...
```

This blocks the explorer frontend `/api/prices` endpoint the first time it queries after a pod restart.

One-liner: import the oracle account before sync. Identical fix to what we did for the publisher in pragma-sdk's Miden client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)