### PR TITLE
fix(oracle-cli): decode publisher word as [w[0], w[1]] (matches median.rs)

### DIFF
--- a/crates/cli/oracle/src/commands/median_batch.rs
+++ b/crates/cli/oracle/src/commands/median_batch.rs
@@ -101,7 +101,11 @@ impl MedianBatchCmd {
                 storage
                     .get_map_item(&publishers_slot, key.into())
                     .with_context(|| format!("Failed to retrieve publisher at index {i}"))
-                    .map(|w| AccountId::new_unchecked([w[3], w[2]]))
+                    // In 0.14 LE, publisher ID word is [prefix, suffix, 0, 0]
+                    // (same convention as median.rs). The previous [w[3], w[2]]
+                    // decoded to all-zero, which manifested in prod as:
+                    //   "account 0x0...0 not found at block ..."
+                    .map(|w| AccountId::new_unchecked([w[0], w[1]]))
             })
             .collect::<Result<_, _>>()
             .context("Failed to collect publisher array")?;

--- a/crates/cli/oracle/src/commands/publishers.rs
+++ b/crates/cli/oracle/src/commands/publishers.rs
@@ -83,8 +83,9 @@ impl PublishersCmd {
             let publisher_word = storage
                 .get_map_item(&publishers_slot, key.into())
                 .with_context(|| format!("Failed to retrieve publisher at index {i}"))?;
-            // VALUE raw: MASM stack has prefix at top -> word[3], suffix -> word[2]
-            let publisher_id = AccountId::new_unchecked([publisher_word[3], publisher_word[2]]);
+            // In 0.14 LE, publisher ID word is [prefix, suffix, 0, 0]
+            // (matches median.rs and the on-chain storage layout).
+            let publisher_id = AccountId::new_unchecked([publisher_word[0], publisher_word[1]]);
 
             let status = if publisher_word != [ZERO, ZERO, ZERO, ZERO].into() {
                 "Active ✅"


### PR DESCRIPTION
Two call sites (`median_batch.rs` and `publishers.rs`) were reading `[w[3], w[2]]` from the oracle storage map while `median.rs` reads `[w[0], w[1]]`. The latter is correct per the comment "In 0.14 LE, publisher ID word is [prefix, suffix, 0, 0]".

Manifested in prod as `account 0x000000000000000000000000000000 not found at block ...` on every `/api/prices` query in the explorer, even though the oracle's storage map definitely contains our publisher `0x2f3aa66d...`.

Aligning both call sites with median.rs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)