### PR TITLE
feat(oracle): reject duplicate publisher registrations

### DIFF
--- a/crates/accounts/src/oracle/mod.rs
+++ b/crates/accounts/src/oracle/mod.rs
@@ -104,7 +104,7 @@ impl<'a> OracleAccountBuilder<'a> {
 
         Self {
             client: None,
-            account_type: ClientAccountType::RegularAccountImmutableCode.to_string(),
+            account_type: ClientAccountType::RegularAccountUpdatableCode.to_string(),
             storage_slots: default_storage_slots,
             keystore_path: "./keystore".to_string(),
         }

--- a/crates/accounts/src/oracle/oracle.masm
+++ b/crates/accounts/src/oracle/oracle.masm
@@ -12,7 +12,7 @@ const MAX_U32=0x0000000100000000
 # =================================================================================================
 
 # Error if the publisher is already registered in the registry
-# const ERR_PUBLISHER_ALREADY_REGISTERED = 100
+const ERR_PUBLISHER_ALREADY_REGISTERED = "publisher already registered"
 
 # Holds the next storage slot index available. Will be used when we register a publisher,
 # so we can assign it a slot.
@@ -345,34 +345,72 @@ end
 #! Can only be called by the Owner of the Oracle account.
 #! Will reserve a storage slot for the publisher if it's not already registered,
 #! which mean this publisher will be able to publish data.
+#! Fails with ERR_PUBLISHER_ALREADY_REGISTERED if the publisher id is already
+#! present in the registry.
 #!
 #! Inputs:  [PUBLISHER_ID]
 #! Outputs: []
 pub proc register_publisher
 
-    # => [PUBLISHER_ID]
+    # => [prefix, suffix, 0, 0]
 
     # Retrieve the next available index from storage
     # get_item returns word in LE: [idx, 0, 0, 0] with idx on top
     push.NEXT_PUBLISHER_INDEX_SLOT[0..2] exec.active_account::get_item
-    # => [idx, 0, 0, 0, PUBLISHER_ID]
+    movdn.3 drop drop drop
+    # => [next_idx, prefix, suffix, 0, 0]
 
-    # KEY = word on top, NEW_VALUE = PUBLISHER_ID right behind
+    # Iterate from PUBLISHERS_STORAGE_SLOT to next_idx-1, fail if (prefix,suffix)
+    # matches any already-registered publisher.
+    push.PUBLISHERS_STORAGE_SLOT exec.felt_is_lower
+    # => [bool, current_idx=2, next_idx, prefix, suffix, 0, 0]
+
+    while.true
+        # => [current_idx, next_idx, prefix, suffix, 0, 0]
+
+        # Build map KEY = [current_idx, 0, 0, 0]
+        dup push.0.0.0 movup.3
+        # => [current_idx, 0, 0, 0, current_idx, next_idx, prefix, suffix, 0, 0]
+
+        push.PUBLISHERS_MAP_SLOT[0..2] exec.active_account::get_map_item
+        # => [stored_prefix, stored_suffix, 0, 0, current_idx, next_idx, prefix, suffix, 0, 0]
+
+        # Compare (stored_prefix, stored_suffix) against (prefix, suffix)
+        dup.6 eq
+        # => [eq_prefix, stored_suffix, 0, 0, current_idx, next_idx, prefix, suffix, 0, 0]
+        swap dup.7 eq
+        # => [eq_suffix, eq_prefix, 0, 0, current_idx, next_idx, prefix, suffix, 0, 0]
+        and
+        # => [is_dup, 0, 0, current_idx, next_idx, prefix, suffix, 0, 0]
+
+        assertz.err=ERR_PUBLISHER_ALREADY_REGISTERED
+        # => [0, 0, current_idx, next_idx, prefix, suffix, 0, 0]
+
+        drop drop
+        # => [current_idx, next_idx, prefix, suffix, 0, 0]
+
+        add.1 exec.felt_is_lower
+    end
+
+    # => [current_idx, next_idx, prefix, suffix, 0, 0]
+    drop drop
+    # => [prefix, suffix, 0, 0]
+
+    # Append the new publisher at index next_idx
+    push.NEXT_PUBLISHER_INDEX_SLOT[0..2] exec.active_account::get_item
+    # => [idx, 0, 0, 0, prefix, suffix, 0, 0]
+
     push.PUBLISHERS_MAP_SLOT[0..2] exec.native_account::set_map_item dropw
     # => []
 
     # Increment next_publisher_index
     push.NEXT_PUBLISHER_INDEX_SLOT[0..2] exec.active_account::get_item
-    # => [idx, 0, 0, 0]
-
-    # Keep idx (top element in LE)
     movdn.3 drop drop drop
     # => [idx]
 
     add.1
-
-    # Rebuild word in LE: [idx+1, 0, 0, 0]
     push.0.0.0 movup.3
+    # => [idx+1, 0, 0, 0]
 
     push.NEXT_PUBLISHER_INDEX_SLOT[0..2] exec.native_account::set_item dropw
     # => []

--- a/crates/accounts/tests/common/mod.rs
+++ b/crates/accounts/tests/common/mod.rs
@@ -199,6 +199,10 @@ pub async fn setup_test_environment(store_filename: String) -> (TestClient, Path
     (client, store_config)
 }
 
+/// Keystore path used by both the test client and the account builders so the
+/// signing key produced at account creation is found by the authenticator.
+const TEST_KEYSTORE_PATH: &str = "./crates/accounts/tests/keystore";
+
 /// Creates and deploys a publisher account with the given entry data
 pub async fn create_and_deploy_publisher_account(
     client: &mut TestClient,
@@ -210,6 +214,7 @@ pub async fn create_and_deploy_publisher_account(
             miden_protocol::account::StorageSlotName::new("pragma::publisher::entries").unwrap(),
             StorageMap::with_entries(vec![(StorageMapKey::new(pair_word), entry_as_word)]).unwrap(),
         )])
+        .with_keystore_path(TEST_KEYSTORE_PATH.to_string())
         .with_client(client)
         .build()
         .await;
@@ -226,7 +231,9 @@ pub async fn create_and_deploy_oracle_account(
     storage_slots: Option<Vec<StorageSlot>>,
 ) -> Result<Account> {
     // Create oracle account builder
-    let mut builder = OracleAccountBuilder::new().with_client(client);
+    let mut builder = OracleAccountBuilder::new()
+        .with_keystore_path(TEST_KEYSTORE_PATH.to_string())
+        .with_client(client);
 
     // Add storage slots if provided
     if let Some(slots) = storage_slots {
@@ -247,15 +254,17 @@ pub async fn create_and_deploy_oracle_account(
     Ok(oracle_account)
 }
 
-/// Deploys the given account by submitting a deployment transaction
+/// Deploys the given account by submitting a no-op transaction. The auth
+/// procedure marked with `@auth_script` on the account is invoked automatically
+/// by the transaction kernel, so the tx script only needs to be a valid no-op.
 async fn deploy_account(
     client: &mut TestClient,
     account_id: AccountId,
 ) -> Result<TransactionId> {
     let deployment_tx_script = CodeBuilder::default().compile_tx_script(
-        "use miden::auth::single_sig
+        "use miden::core::sys
         begin
-            call.::miden::auth::single_sig::authenticate_transaction
+            exec.sys::truncate_stack
         end",
     )?;
 


### PR DESCRIPTION
## Problem

`register_publisher` previously appended unconditionally, so calling it twice with the same publisher id silently created two registry entries pointing at the same account. `get_median` would then double-count that publisher's price, biasing the result toward whichever publisher was duplicated.

## Fix

Linear dedupe pass before appending: iterate over the already-registered publishers and assert that none matches the incoming `(prefix, suffix)`. Uses `ERR_PUBLISHER_ALREADY_REGISTERED = \"publisher already registered\"` (error consts are strings since Miden v0.22).

Also switches the default oracle account type from `RegularAccountImmutableCode` to `RegularAccountUpdatableCode`, so subsequent MASM upgrades (the staleness and publisher-removal PRs to follow) can update the existing oracle in place instead of forcing a fresh redeploy each time.

## Test infra cleanup (unblocks main)

The test suite was already broken on `main` before this PR — included here because we needed it green to validate the dedupe path:

- the deploy tx script was calling `miden::auth::single_sig::authenticate_transaction`, a symbol that no longer exists in Miden v0.14. Replaced with a no-op tx script — the `@auth_script` proc on the account is invoked automatically by the kernel.
- `Oracle/PublisherAccountBuilder` default keystore path was `./keystore` while `setup_devnet_client` used `./crates/accounts/tests/keystore`, so the signing key created at build-time was never found by the authenticator. Pass the test keystore path explicitly.

## Test plan

\`\`\`
cargo test -p pm-accounts --test test_oracle test_oracle_register_publisher -- --test-threads=1
\`\`\`

- `test_oracle_register_publisher` ✓
- `test_oracle_register_publisher_fails_if_publisher_already_registered` ✓ (was previously failing because the dedupe logic didn't exist)

## After deploy

Production oracle (`0xd0e1384e21a6350029d80128eb5c44`) is `RegularAccountImmutableCode`, so this PR requires a fresh oracle redeploy. The new account will be `RegularAccountUpdatableCode`, unblocking in-place upgrades for the next two PRs (staleness in `get_median`, soft-delete `remove_publisher`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)