### PR TITLE
feat(oracle): skip stale entries in get_median (>1h)

### DIFF
--- a/crates/accounts/src/oracle/oracle.masm
+++ b/crates/accounts/src/oracle/oracle.masm
@@ -17,6 +17,11 @@ const ERR_PUBLISHER_ALREADY_REGISTERED = "publisher already registered"
 # Error if the publisher to remove is not present in the registry
 const ERR_PUBLISHER_NOT_REGISTERED = "publisher not registered"
 
+# Maximum age (in seconds, relative to the reference block timestamp) for a
+# publisher entry to be included in the median computation. Entries older than
+# this threshold are skipped — same path as soft-deleted slots.
+const MAX_ENTRY_AGE_SECONDS=3600
+
 # Holds the next storage slot index available. Will be used when we register a publisher,
 # so we can assign it a slot.
 const NEXT_PUBLISHER_INDEX_SLOT=word("pragma::oracle::next_publisher_index")
@@ -323,15 +328,37 @@ pub proc get_median
             # => [PUBLISHER_ID, faucet_id_word, current_slot, next_slot, fid_p, fid_s, 0, 0]
 
             exec.call_publisher_get_entry
-            # => [ENTRY, current_slot, next_slot, fid_p, fid_s, 0, 0]
+            # => [ts, decimals, price, 0, current_slot, next_slot, fid_p, fid_s, 0, 0]
 
-            # Write ENTRY at offset valid_count * 4
-            mem_load.10001 mul.4
-            mem_storew_be dropw
-            # => [current_slot, next_slot, fid_p, fid_s, 0, 0]
+            # Staleness check. The entry's timestamp is at depth 0 (Miden stores
+            # the published word with the last-pushed felt on top — see
+            # publisher CLI's `push.{entry}` over `[0, price, decimals, ts]`).
+            # Skip if `(now - entry_ts) > MAX_ENTRY_AGE_SECONDS`.
+            exec.tx::get_block_timestamp
+            # => [now, ts, decimals, price, 0, ...]
+            dup.1
+            # => [ts, now, ts, decimals, price, 0, ...]
+            sub
+            # => [age=now-ts, ts, decimals, price, 0, ...]
+            push.MAX_ENTRY_AGE_SECONDS exec.felt_is_lower
+            # => [is_stale=(MAX_AGE<age), MAX_AGE, age, ts, decimals, price, 0, ...]
 
-            # Increment valid_count
-            mem_load.10001 add.1 mem_store.10001
+            if.true
+                # Stale: drop MAX_AGE, age, ts, decimals, price, 0 (6 felts).
+                drop drop drop drop drop drop
+                # => [current_slot, next_slot, fid_p, fid_s, 0, 0]
+            else
+                # Fresh: drop MAX_AGE, age — leave [ts, decimals, price, 0] for
+                # the RAM write, then bump valid_count.
+                drop drop
+                # => [ts, decimals, price, 0, current_slot, next_slot, fid_p, fid_s, 0, 0]
+
+                mem_load.10001 mul.4
+                mem_storew_be dropw
+                # => [current_slot, next_slot, fid_p, fid_s, 0, 0]
+
+                mem_load.10001 add.1 mem_store.10001
+            end
         end
 
         add.1 exec.felt_is_lower


### PR DESCRIPTION
> Stacked on top of #53 (PR 2 — soft-delete). Will rebase onto its parent once #53 merges.

## What

Entries whose timestamp is older than \`MAX_ENTRY_AGE_SECONDS = 3600s\` relative to the reference block timestamp are skipped in the median computation. Same path as soft-deleted slots: no RAM write, no \`valid_count\` increment. If everything is stale, the oracle returns \`(is_tracked=0, median=0)\`.

The staleness check runs **after** \`call_publisher_get_entry\` (we still pay the FPI cost, but that's required to read the timestamp in the first place). \`now\` comes from \`miden::protocol::tx::get_block_timestamp\`; the comparison reuses the existing \`felt_is_lower\` helper.

## Why hardcoded 3600

Per discussion: keep the threshold inside the contract for now, not a per-call parameter. Easier to reason about for consumers, and once the staleness guarantee is published, it shouldn't be silently weakened by callers. We can revisit if a use case actually needs sub-hour or longer windows.

## Local-node validation

\`\`\`
oracle: 0xe601492b255697106fefe7a0f43491
pub1:   0x72d85bee346adb000c9585bfeb4f6c — publishes BTC/USD=\$50_000 with ts=10  (stale)
pub2:   0x48f66720c3a1b30032c57ea90d067f — publishes BTC/USD=\$52_000 with ts=now (fresh)
\`\`\`

After registering both:

\`\`\`
\$ pm-oracle-cli --network local median 1:0
[DBG] found 2 publishers on-chain
[DBG] publisher 0x72d8...c imported
[DBG] publisher 0x48f6...f imported
Median value: 5200000000000 (amount: 0)   # = \$52_000, pub2 only
\`\`\`

If staleness were missing, this would return \`5_100_000_000_000\` (= avg of \$50_000 and \$52_000). The MASM correctly skipped pub1's stale entry.

## Test plan

\`\`\`
cargo test -p pm-accounts
\`\`\`

- All 5 existing tests still pass (\`tx::get_block_timestamp\` in mockchain returns a value close enough to the 2025 entry timestamps for them to fall in the fresh branch).
- End-to-end stale-skip behavior verified on local-node (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)