### PR TITLE
ci: fast MockChain CI + fmt/clippy gates (replace broken miden-node workflow)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: CI
 
 on:
   push:
@@ -6,175 +6,40 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
 jobs:
   test:
-    name: Build and Test
+    name: Build & Test
     runs-on: ubuntu-latest
-    
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          token: ${{ github.token }}
-      
-      - name: Install Rust (simplified for act)
-        if: ${{ env.ACT }}
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          source "$HOME/.cargo/env"
-          
-          # Install specific nightly toolchain for edition 2024 support
-          rustup toolchain install nightly-2025-03-11
-          rustup default nightly-2025-03-11
-          
-          rustup component add rustfmt clippy
-      
-      - name: Install Rust (GitHub Actions)
-        if: ${{ !env.ACT }}
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2025-03-11
-          override: true
-          components: rustfmt, clippy
-      
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-      
-      - name: Cleanup existing containers
-        run: |
-          # Stop and remove any existing containers with the same names
-          docker stop miden-node miden-node-init miden-node-genesis 2>/dev/null || true
-          docker rm miden-node miden-node-init miden-node-genesis 2>/dev/null || true
-      
-      - name: Checkout Miden Node v0.8
-        uses: actions/checkout@v3
-        with:
-          repository: 0xPolygonMiden/miden-node
-          path: miden-node
-          ref: v0.8
-          token: ${{ github.token }}
-      
-      - name: Clone Miden Node (fallback)
-        if: ${{ failure() }}
-        run: |
-          git clone --depth 1 --branch v0.8 https://github.com/0xPolygonMiden/miden-node.git miden-node
-      
-      - name: Build Miden Node Docker Image
-        run: |
-          cd miden-node
-          
-          # Build the Docker image using the commands from the Makefile
-          CREATED=$(date) && \
-          VERSION=$(cat bin/node/Cargo.toml | grep -m 1 '^version' | cut -d '"' -f 2) && \
-          COMMIT=$(git rev-parse HEAD) && \
-          docker build --build-arg CREATED="$CREATED" \
-                      --build-arg VERSION="$VERSION" \
-                      --build-arg COMMIT="$COMMIT" \
-                      -f bin/node/Dockerfile \
-                      -t miden-node-image .
-      
-      - name: Initialize and Start Miden Node
-        run: |
-          # Clean up any existing data directory
-          rm -rf data accounts
-          
-          # Create directories for node data and accounts
-          mkdir -p data
-          mkdir -p accounts
-          
-          # Generate genesis configuration
-          docker run --name miden-node-genesis \
-                    -v "$(pwd):/workspace" \
-                    -w /workspace \
-                    miden-node-image \
-                    miden-node store dump-genesis > genesis.toml
-          
-          # Bootstrap the node
-          docker run --name miden-node-bootstrap \
-                    -v "$(pwd):/workspace" \
-                    -w /workspace \
-                    miden-node-image \
-                    miden-node bundled bootstrap \
-                    --data-directory data \
-                    --accounts-directory accounts \
-                    --config genesis.toml
-          
-          # Clean up bootstrap container
-          docker rm miden-node-bootstrap miden-node-genesis
-          
-          # Start the node
-          docker run --name miden-node \
-                    -p 57123:57123 \
-                    -v "$(pwd):/workspace" \
-                    -w /workspace \
-                    -d miden-node-image \
-                    miden-node bundled start \
-                    --data-directory data \
-                    --rpc.url http://0.0.0.0:57123
-          
-          # Wait for the node to start
-          echo "Waiting for Miden node to start..."
-          sleep 30
-          
-          # Check if the node is running
-          if ! docker ps | grep miden-node > /dev/null; then
-            echo "Miden node failed to start"
-            docker logs miden-node || true
-            exit 1
-          else
-            echo "Miden node started successfully"
-            docker logs miden-node
-          fi
-      
-      - name: Build Project
-        run: |
-          # Source cargo environment if running with act
-          if [ -n "$ACT" ]; then
-            source "$HOME/.cargo/env"
-          fi
-          
-          cargo build --verbose
-      
-      - name: Run tests
-        run: |
-          # Source cargo environment if running with act
-          if [ -n "$ACT" ]; then
-            source "$HOME/.cargo/env"
-          fi
-          
-          # Set environment variables to connect to the Docker container
-          export MIDEN_NODE_URL=http://localhost:57291
-          export RUST_BACKTRACE=1
-          
-          # Run tests one at a time to avoid database conflicts
-          echo "Running test_oracle_get_entry..."
-          cargo test --package pm-accounts --test test_oracle test_oracle_get_entry --verbose -- --nocapture
-          
-          echo "Running test_oracle_register_publisher..."
-          cargo test --package pm-accounts --test test_oracle test_oracle_register_publisher --verbose -- --nocapture
-          
-          echo "Running test_oracle_get_median..."
-          cargo test --package pm-accounts --test test_oracle test_oracle_get_median --verbose -- --nocapture
-          
-          echo "Running test_publisher tests..."
-          cargo test --package pm-accounts --test test_publisher --verbose -- --nocapture
-      
-      - name: Show Node Logs
-        if: always()
-        run: |
-          docker logs miden-node || true
-      
-      - name: Stop Miden Node
-        if: always()
-        run: |
-          docker stop miden-node || true
-          docker rm miden-node || true 
+      - uses: actions/checkout@v4
+
+      # Installs the toolchain pinned in rust-toolchain.toml (channel, clippy,
+      # rustfmt, wasm32 target) and caches the cargo registry + target dir.
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      # All oracle tests run in-process against miden_testing::MockChain, so no
+      # external miden-node is needed. `--workspace` also compiles the
+      # examples/consume-price member (excluded from default-members).
+      - name: Build
+        run: cargo build --workspace --all-targets --verbose
+
+      - name: Test
+        run: cargo test --workspace --verbose
+
+  lint:
+    name: Lint (fmt + clippy)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: rustfmt
+        run: cargo fmt --all --check
+
+      - name: clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings

--- a/crates/accounts/src/oracle/mod.rs
+++ b/crates/accounts/src/oracle/mod.rs
@@ -13,7 +13,10 @@ use miden_client::{
     Client, Felt, Word, ZERO,
 };
 use miden_protocol::{
-    account::{AccountBuilder, AccountComponent, AccountComponentMetadata, AccountType, StorageSlot, StorageSlotName},
+    account::{
+        AccountBuilder, AccountComponent, AccountComponentMetadata, AccountType, StorageSlot,
+        StorageSlotName,
+    },
     assembly::{DefaultSourceManager, Library, Module, ModuleKind, Path as LibraryPath},
     transaction::TransactionKernel,
 };
@@ -36,9 +39,7 @@ pub fn oracle_storage_slots() -> Vec<StorageSlot> {
             StorageSlotName::new("pragma::oracle::next_publisher_index").unwrap(),
             [Felt::new(2), ZERO, ZERO, ZERO].into(),
         ),
-        StorageSlot::with_empty_map(
-            StorageSlotName::new("pragma::oracle::publishers").unwrap(),
-        ),
+        StorageSlot::with_empty_map(StorageSlotName::new("pragma::oracle::publishers").unwrap()),
     ]
 }
 
@@ -120,10 +121,7 @@ impl<'a> OracleAccountBuilder<'a> {
         self
     }
 
-    pub fn with_client(
-        mut self,
-        client: &'a mut Client<FilesystemKeyStore>,
-    ) -> Self {
+    pub fn with_client(mut self, client: &'a mut Client<FilesystemKeyStore>) -> Self {
         self.client = Some(client);
         self
     }
@@ -141,7 +139,10 @@ impl<'a> OracleAccountBuilder<'a> {
         let private_key = SecretKey::with_rng(client_rng);
         let public_key = private_key.public_key();
 
-        let auth_component = AuthSingleSig::new(public_key.to_commitment().into(), AuthScheme::Falcon512Poseidon2);
+        let auth_component = AuthSingleSig::new(
+            public_key.to_commitment().into(),
+            AuthScheme::Falcon512Poseidon2,
+        );
         let from_seed = client_rng.random();
 
         let account = AccountBuilder::new(from_seed)
@@ -156,7 +157,10 @@ impl<'a> OracleAccountBuilder<'a> {
 
         let keystore = FilesystemKeyStore::new(self.keystore_path.into()).unwrap();
         keystore
-            .add_key(&AuthSecretKey::Falcon512Poseidon2(private_key), account.id())
+            .add_key(
+                &AuthSecretKey::Falcon512Poseidon2(private_key),
+                account.id(),
+            )
             .await
             .unwrap();
 

--- a/crates/accounts/src/oracle/mod.rs
+++ b/crates/accounts/src/oracle/mod.rs
@@ -69,7 +69,7 @@ pub fn get_median_procedure_hash() -> String {
         })
         .expect("get_median procedure not found in oracle library");
 
-    let node_id = lib.get_export_node_id(&export.path());
+    let node_id = lib.get_export_node_id(export.path());
     let digest = lib
         .mast_forest()
         .get_node_by_id(node_id)

--- a/crates/accounts/src/publisher/mod.rs
+++ b/crates/accounts/src/publisher/mod.rs
@@ -39,7 +39,7 @@ pub fn get_entry_procedure_hash() -> String {
         })
         .expect("get_entry procedure not found in publisher library");
 
-    let node_id = lib.get_export_node_id(&export.path());
+    let node_id = lib.get_export_node_id(export.path());
     let digest = lib
         .mast_forest()
         .get_node_by_id(node_id)

--- a/crates/accounts/src/publisher/mod.rs
+++ b/crates/accounts/src/publisher/mod.rs
@@ -14,7 +14,10 @@ use miden_client::{
 };
 
 use miden_protocol::{
-    account::{AccountBuilder, AccountComponent, AccountComponentMetadata, AccountType, StorageSlot, StorageSlotName},
+    account::{
+        AccountBuilder, AccountComponent, AccountComponentMetadata, AccountType, StorageSlot,
+        StorageSlotName,
+    },
     assembly::{DefaultSourceManager, Library, Module, ModuleKind, Path as LibraryPath},
     transaction::TransactionKernel,
 };
@@ -70,12 +73,10 @@ pub fn get_publisher_component_library() -> Arc<Library> {
 pub fn get_publisher_component() -> AccountComponent {
     let library = get_publisher_component_library();
     let library = Arc::try_unwrap(library).unwrap_or_else(|arc| (*arc).clone());
-    let storage_slot = StorageSlot::with_empty_map(
-        StorageSlotName::new("pragma::publisher::entries").unwrap()
-    );
+    let storage_slot =
+        StorageSlot::with_empty_map(StorageSlotName::new("pragma::publisher::entries").unwrap());
     let metadata = AccountComponentMetadata::new("pragma::publisher", AccountType::all());
-    AccountComponent::new(library, vec![storage_slot], metadata)
-        .expect("assembly should succeed")
+    AccountComponent::new(library, vec![storage_slot], metadata).expect("assembly should succeed")
 }
 
 pub struct PublisherAccountBuilder<'a> {
@@ -87,11 +88,9 @@ pub struct PublisherAccountBuilder<'a> {
 
 impl<'a> PublisherAccountBuilder<'a> {
     pub fn new() -> Self {
-        let default_storage_slots = vec![
-            StorageSlot::with_empty_map(
-                StorageSlotName::new("pragma::publisher::entries").unwrap()
-            )
-        ];
+        let default_storage_slots = vec![StorageSlot::with_empty_map(
+            StorageSlotName::new("pragma::publisher::entries").unwrap(),
+        )];
         Self {
             client: None,
             account_type: AccountType::RegularAccountImmutableCode,
@@ -110,10 +109,7 @@ impl<'a> PublisherAccountBuilder<'a> {
         self
     }
 
-    pub fn with_client(
-        mut self,
-        client: &'a mut Client<FilesystemKeyStore>,
-    ) -> Self {
+    pub fn with_client(mut self, client: &'a mut Client<FilesystemKeyStore>) -> Self {
         self.client = Some(client);
         self
     }
@@ -129,7 +125,10 @@ impl<'a> PublisherAccountBuilder<'a> {
         let private_key = SecretKey::with_rng(client_rng);
         let public_key = private_key.public_key();
 
-        let auth_component = AuthSingleSig::new(public_key.to_commitment().into(), AuthScheme::Falcon512Poseidon2);
+        let auth_component = AuthSingleSig::new(
+            public_key.to_commitment().into(),
+            AuthScheme::Falcon512Poseidon2,
+        );
 
         let publisher_component: AccountComponent = get_publisher_component();
         let from_seed = client_rng.random();
@@ -147,7 +146,10 @@ impl<'a> PublisherAccountBuilder<'a> {
         client.add_account(&account, true).await.unwrap();
         let keystore = FilesystemKeyStore::new(self.keystore_path.into()).unwrap();
         keystore
-            .add_key(&AuthSecretKey::Falcon512Poseidon2(private_key), account.id())
+            .add_key(
+                &AuthSecretKey::Falcon512Poseidon2(private_key),
+                account.id(),
+            )
             .await
             .unwrap();
 

--- a/crates/accounts/tests/test_oracle.rs
+++ b/crates/accounts/tests/test_oracle.rs
@@ -72,7 +72,7 @@ fn register_publisher_script(publisher_id: AccountId) -> Result<TransactionScrip
         suffix = publisher_id.suffix(),
     );
     Ok(CodeBuilder::default()
-        .with_statically_linked_library(&*get_oracle_component_library())?
+        .with_statically_linked_library(&get_oracle_component_library())?
         .compile_tx_script(tx_script_code)?)
 }
 
@@ -93,7 +93,7 @@ fn remove_publisher_script(publisher_id: AccountId) -> Result<TransactionScript>
         suffix = publisher_id.suffix(),
     );
     Ok(CodeBuilder::default()
-        .with_statically_linked_library(&*get_oracle_component_library())?
+        .with_statically_linked_library(&get_oracle_component_library())?
         .compile_tx_script(tx_script_code)?)
 }
 
@@ -112,7 +112,7 @@ fn get_median_script(pair_word: Word) -> Result<TransactionScript> {
         pair = word_to_masm(pair_word),
     );
     Ok(CodeBuilder::default()
-        .with_statically_linked_library(&*get_oracle_component_library())?
+        .with_statically_linked_library(&get_oracle_component_library())?
         .compile_tx_script(tx_script_code)?)
 }
 

--- a/crates/cli/oracle/src/commands/get_entry.rs
+++ b/crates/cli/oracle/src/commands/get_entry.rs
@@ -4,9 +4,9 @@ use std::path::Path;
 use miden_client::account::AccountId;
 use miden_client::rpc::domain::account::AccountStorageRequirements;
 use miden_client::transaction::ForeignAccount;
+use miden_client::{keystore::FilesystemKeyStore, Client, Felt};
 use miden_protocol::account::{StorageMapKey, StorageSlotName};
 use miden_standards::code_builder::CodeBuilder;
-use miden_client::{keystore::FilesystemKeyStore, Client, Felt};
 
 use miden_protocol::vm::AdviceInputs;
 use pm_accounts::oracle::get_oracle_component_library;
@@ -76,7 +76,10 @@ impl GetEntryCmd {
             .map_err(|e| anyhow::anyhow!("Invalid storage slot name: {e:?}"))?;
         let foreign_account = ForeignAccount::public(
             publisher.id(),
-            AccountStorageRequirements::new([(publisher_entries_slot, &[StorageMapKey::new(faucet_id_word)])]),
+            AccountStorageRequirements::new([(
+                publisher_entries_slot,
+                &[StorageMapKey::new(faucet_id_word)],
+            )]),
         )?;
         let tx_script_code = format!(
             "

--- a/crates/cli/oracle/src/commands/median.rs
+++ b/crates/cli/oracle/src/commands/median.rs
@@ -2,10 +2,10 @@ use anyhow::Context;
 use miden_client::account::AccountId;
 use miden_client::rpc::domain::account::AccountStorageRequirements;
 use miden_client::transaction::ForeignAccount;
-use miden_protocol::account::{StorageMapKey, StorageSlotName};
-use miden_standards::code_builder::CodeBuilder;
 use miden_client::{keystore::FilesystemKeyStore, Client, Felt, Word, ZERO};
+use miden_protocol::account::{StorageMapKey, StorageSlotName};
 use miden_protocol::vm::AdviceInputs;
+use miden_standards::code_builder::CodeBuilder;
 use pm_accounts::oracle::get_oracle_component_library;
 use pm_utils_cli::{get_oracle_id, PRAGMA_ACCOUNTS_STORAGE_FILE};
 use std::collections::BTreeMap;
@@ -15,7 +15,7 @@ use std::path::Path;
 #[clap(about = "Compute the median for a given faucet_id")]
 pub struct MedianCmd {
     pub faucet_id: String,
-    
+
     /// Optional amount parameter (defaults to 0)
     #[clap(short, long, default_value = "0")]
     pub amount: u64,
@@ -40,12 +40,16 @@ impl MedianCmd {
 
         let parts: Vec<&str> = self.faucet_id.split(':').collect();
         if parts.len() != 2 {
-            return Err(anyhow::anyhow!("Invalid faucet_id format. Expected PREFIX:SUFFIX (e.g., 1:0)"));
+            return Err(anyhow::anyhow!(
+                "Invalid faucet_id format. Expected PREFIX:SUFFIX (e.g., 1:0)"
+            ));
         }
 
-        let prefix = parts[0].parse::<u64>()
+        let prefix = parts[0]
+            .parse::<u64>()
             .map_err(|_| anyhow::anyhow!("Invalid faucet_id prefix: {}", parts[0]))?;
-        let suffix = parts[1].parse::<u64>()
+        let suffix = parts[1]
+            .parse::<u64>()
             .map_err(|_| anyhow::anyhow!("Invalid faucet_id suffix: {}", parts[1]))?;
 
         let faucet_id_word: Word = [
@@ -53,7 +57,8 @@ impl MedianCmd {
             Felt::new(0),
             Felt::new(suffix),
             Felt::new(prefix),
-        ].into();
+        ]
+        .into();
 
         // Re-import oracle from chain to get fresh storage state
         client.import_account_by_id(oracle_id).await?;
@@ -97,7 +102,10 @@ impl MedianCmd {
             eprintln!("[DBG] publisher {publisher_id} imported");
             let foreign_account = ForeignAccount::public(
                 publisher_id,
-                AccountStorageRequirements::new([(publisher_entries_slot.clone(), &[StorageMapKey::new(faucet_id_word)])]),
+                AccountStorageRequirements::new([(
+                    publisher_entries_slot.clone(),
+                    &[StorageMapKey::new(faucet_id_word)],
+                )]),
             )?;
             foreign_accounts.push(foreign_account);
         }
@@ -126,8 +134,12 @@ impl MedianCmd {
             .compile_tx_script(tx_script_code.clone())
             .map_err(|e| anyhow::anyhow!("Error while compiling the script: {e:?}"))?;
 
-        let foreign_accounts_map: BTreeMap<AccountId, ForeignAccount> = foreign_accounts.into_iter().map(|fa| (fa.account_id(), fa)).collect();
-        let output_stack = client.execute_program(
+        let foreign_accounts_map: BTreeMap<AccountId, ForeignAccount> = foreign_accounts
+            .into_iter()
+            .map(|fa| (fa.account_id(), fa))
+            .collect();
+        let output_stack = client
+            .execute_program(
                 oracle_id,
                 median_script,
                 AdviceInputs::default(),
@@ -136,12 +148,13 @@ impl MedianCmd {
             .await
             .map_err(|e| anyhow::anyhow!("execute_program error: {e:?}"))?;
 
-
         // Stack output: [amount, is_tracked, median_price]
         if output_stack.len() < 3 {
-            return Err(anyhow::anyhow!("Invalid output: expected [amount, is_tracked, median_price]"));
+            return Err(anyhow::anyhow!(
+                "Invalid output: expected [amount, is_tracked, median_price]"
+            ));
         }
-        
+
         let is_tracked = output_stack[0];
         let median = output_stack[1];
         let returned_amount = output_stack[2];

--- a/crates/cli/oracle/src/commands/median.rs
+++ b/crates/cli/oracle/src/commands/median.rs
@@ -32,7 +32,7 @@ impl MedianCmd {
         client.import_account_by_id(oracle_id).await?;
         client.sync_state().await?;
         eprintln!("[DBG] sync1 done");
-        let account = client
+        let _account = client
             .get_account(oracle_id)
             .await?
             .expect("Oracle account not found");

--- a/crates/cli/oracle/src/commands/median_batch.rs
+++ b/crates/cli/oracle/src/commands/median_batch.rs
@@ -2,10 +2,10 @@ use anyhow::Context;
 use miden_client::account::AccountId;
 use miden_client::rpc::domain::account::AccountStorageRequirements;
 use miden_client::transaction::ForeignAccount;
-use miden_protocol::account::{StorageMapKey, StorageSlotName};
-use miden_standards::code_builder::CodeBuilder;
 use miden_client::{keystore::FilesystemKeyStore, Client, Felt, Word, ZERO};
+use miden_protocol::account::{StorageMapKey, StorageSlotName};
 use miden_protocol::vm::AdviceInputs;
+use miden_standards::code_builder::CodeBuilder;
 use pm_accounts::oracle::get_oracle_component_library;
 
 use pm_utils_cli::{get_oracle_id, PRAGMA_ACCOUNTS_STORAGE_FILE};
@@ -85,8 +85,9 @@ impl MedianBatchCmd {
         let storage = account.storage();
 
         // Get publisher count from storage
-        let next_publisher_index_slot = StorageSlotName::new("pragma::oracle::next_publisher_index")
-            .map_err(|e| anyhow::anyhow!("Invalid storage slot name: {e:?}"))?;
+        let next_publisher_index_slot =
+            StorageSlotName::new("pragma::oracle::next_publisher_index")
+                .map_err(|e| anyhow::anyhow!("Invalid storage slot name: {e:?}"))?;
         let publisher_count = storage
             .get_item(&next_publisher_index_slot)
             .context("Unable to retrieve publisher count")?[0]
@@ -118,20 +119,26 @@ impl MedianBatchCmd {
         for faucet_id_str in &self.faucet_ids {
             let parts: Vec<&str> = faucet_id_str.split(':').collect();
             if parts.len() != 2 {
-                return Err(anyhow::anyhow!("Invalid faucet_id format: {}. Expected PREFIX:SUFFIX (e.g., 1:0)", faucet_id_str));
+                return Err(anyhow::anyhow!(
+                    "Invalid faucet_id format: {}. Expected PREFIX:SUFFIX (e.g., 1:0)",
+                    faucet_id_str
+                ));
             }
-            
-            let prefix = parts[0].parse::<u64>()
+
+            let prefix = parts[0]
+                .parse::<u64>()
                 .map_err(|_| anyhow::anyhow!("Invalid faucet_id prefix: {}", parts[0]))?;
-            let suffix = parts[1].parse::<u64>()
+            let suffix = parts[1]
+                .parse::<u64>()
                 .map_err(|_| anyhow::anyhow!("Invalid faucet_id suffix: {}", parts[1]))?;
-            
+
             let faucet_id_word: Word = [
                 Felt::new(0),
                 Felt::new(0),
                 Felt::new(suffix),
                 Felt::new(prefix),
-            ].into();
+            ]
+            .into();
 
             let mut foreign_accounts: Vec<ForeignAccount> = vec![];
             let publisher_entries_slot = StorageSlotName::new("pragma::publisher::entries")
@@ -171,8 +178,10 @@ impl MedianBatchCmd {
                 .compile_tx_script(tx_script_code.clone())
                 .map_err(|e| anyhow::anyhow!("Error while compiling the script: {e:?}"))?;
 
-            let foreign_accounts_map: BTreeMap<AccountId, ForeignAccount> =
-                foreign_accounts.into_iter().map(|fa| (fa.account_id(), fa)).collect();
+            let foreign_accounts_map: BTreeMap<AccountId, ForeignAccount> = foreign_accounts
+                .into_iter()
+                .map(|fa| (fa.account_id(), fa))
+                .collect();
 
             let output_stack = client
                 .execute_program(
@@ -182,12 +191,17 @@ impl MedianBatchCmd {
                     foreign_accounts_map,
                 )
                 .await
-                .with_context(|| format!("Failed to execute median for faucet_id: {}", faucet_id_str))?;
+                .with_context(|| {
+                    format!("Failed to execute median for faucet_id: {}", faucet_id_str)
+                })?;
 
             if output_stack.len() < 3 {
-                return Err(anyhow::anyhow!("Invalid output for {}: expected [is_tracked, median_price, amount]", faucet_id_str));
+                return Err(anyhow::anyhow!(
+                    "Invalid output for {}: expected [is_tracked, median_price, amount]",
+                    faucet_id_str
+                ));
             }
-            
+
             let is_tracked = output_stack[0].as_canonical_u64();
             let median = output_stack[1].as_canonical_u64();
             let amount = output_stack[2].as_canonical_u64();
@@ -202,15 +216,21 @@ impl MedianBatchCmd {
 
         // STEP 3: Output results
         if self.json {
-            let json_output = serde_json::to_string(&results)
-                .context("Failed to serialize results to JSON")?;
+            let json_output =
+                serde_json::to_string(&results).context("Failed to serialize results to JSON")?;
             println!("{}", json_output);
         } else {
             for result in &results {
                 if result.is_tracked {
-                    println!("{}: {} (amount: {})", result.faucet_id, result.median, result.amount);
+                    println!(
+                        "{}: {} (amount: {})",
+                        result.faucet_id, result.median, result.amount
+                    );
                 } else {
-                    println!("{}: Not tracked (amount: {})", result.faucet_id, result.amount);
+                    println!(
+                        "{}: Not tracked (amount: {})",
+                        result.faucet_id, result.amount
+                    );
                 }
             }
         }

--- a/crates/cli/oracle/src/commands/publishers.rs
+++ b/crates/cli/oracle/src/commands/publishers.rs
@@ -95,7 +95,7 @@ impl PublishersCmd {
 
             table.add_row(Row::new(vec![
                 Cell::new(&format!("{}", i - 1)).style_spec("Fg"),
-                Cell::new(&format!("{}", publisher_id.to_hex())).style_spec("Fy"),
+                Cell::new(&publisher_id.to_hex().to_string()).style_spec("Fy"),
                 Cell::new(status).style_spec("Fw"),
             ]));
         }

--- a/crates/cli/oracle/src/commands/register_publisher.rs
+++ b/crates/cli/oracle/src/commands/register_publisher.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 
 use miden_client::account::AccountId;
 use miden_client::transaction::TransactionRequestBuilder;
-use miden_standards::code_builder::CodeBuilder;
 use miden_client::{keystore::FilesystemKeyStore, Client};
+use miden_standards::code_builder::CodeBuilder;
 use pm_accounts::oracle::get_oracle_component_library;
 use pm_utils_cli::{get_oracle_id, PRAGMA_ACCOUNTS_STORAGE_FILE};
 
@@ -87,7 +87,9 @@ impl RegisterPublisherCmd {
             .await
             .map_err(|e| anyhow::anyhow!("Error while submitting transaction: {e:?}"))?;
 
-        client.sync_state().await
+        client
+            .sync_state()
+            .await
             .map_err(|e| anyhow::anyhow!("Error while syncing state after register: {e:?}"))?;
 
         println!("✅ Register successful!");

--- a/crates/cli/oracle/src/commands/sync.rs
+++ b/crates/cli/oracle/src/commands/sync.rs
@@ -5,10 +5,7 @@ use miden_client::{keystore::FilesystemKeyStore, Client};
 pub struct SyncCmd {}
 
 impl SyncCmd {
-    pub async fn call(
-        &self,
-        client: &mut Client<FilesystemKeyStore>,
-    ) -> anyhow::Result<()> {
+    pub async fn call(&self, client: &mut Client<FilesystemKeyStore>) -> anyhow::Result<()> {
         let _ = client
             .sync_state()
             .await

--- a/crates/cli/oracle/src/commands/sync.rs
+++ b/crates/cli/oracle/src/commands/sync.rs
@@ -9,7 +9,7 @@ impl SyncCmd {
         let _ = client
             .sync_state()
             .await
-            .map_err(|e| anyhow::anyhow!("Could not sync state: {}", e.to_string()))?;
+            .map_err(|e| anyhow::anyhow!("Could not sync state: {}", e))?;
 
         println!("🔁 Sync successful!\n");
         Ok(())

--- a/crates/cli/oracle/src/main.rs
+++ b/crates/cli/oracle/src/main.rs
@@ -20,7 +20,10 @@ async fn main() -> anyhow::Result<()> {
     let output = cli.command.call(&cli.network).await?;
     match output {
         commands::CommandOutput::Entry(entry) => {
-            println!("Price: {}, Decimals: {}, Timestamp: {}", entry.price, entry.decimals, entry.timestamp);
+            println!(
+                "Price: {}, Decimals: {}, Timestamp: {}",
+                entry.price, entry.decimals, entry.timestamp
+            );
         }
         commands::CommandOutput::Felt(f) => {
             println!("{}", f);

--- a/crates/cli/publisher/src/commands/entry.rs
+++ b/crates/cli/publisher/src/commands/entry.rs
@@ -14,8 +14,6 @@ pub struct EntryCmd {
     pub faucet_id: String,
 }
 
-
-
 impl EntryCmd {
     pub async fn call(
         &self,
@@ -52,8 +50,9 @@ impl EntryCmd {
         ]
         .into();
 
-        let publisher_entries_slot = miden_protocol::account::StorageSlotName::new("pragma::publisher::entries")
-            .map_err(|e| anyhow::anyhow!("Invalid storage slot name: {e:?}"))?;
+        let publisher_entries_slot =
+            miden_protocol::account::StorageSlotName::new("pragma::publisher::entries")
+                .map_err(|e| anyhow::anyhow!("Invalid storage slot name: {e:?}"))?;
         let entry_word = publisher
             .storage()
             .get_map_item(&publisher_entries_slot, faucet_id_word)

--- a/crates/cli/publisher/src/commands/get_entry.rs
+++ b/crates/cli/publisher/src/commands/get_entry.rs
@@ -1,6 +1,6 @@
 use miden_client::{keystore::FilesystemKeyStore, Client, Felt};
-use miden_standards::code_builder::CodeBuilder;
 use miden_protocol::vm::AdviceInputs;
+use miden_standards::code_builder::CodeBuilder;
 use pm_accounts::publisher::get_publisher_component_library;
 use pm_accounts::utils::word_to_masm;
 use pm_types::Entry;

--- a/crates/cli/publisher/src/commands/mod.rs
+++ b/crates/cli/publisher/src/commands/mod.rs
@@ -17,6 +17,10 @@ use publish::PublishCmd;
 use publish_batch::PublishBatchCmd;
 use sync::SyncCmd;
 
+// `commands` is shared by the pm-publisher binary (which dispatches through
+// SubCommand::call) and the pyo3 lib (which calls each subcommand directly), so
+// these dispatch helpers read as dead code in the lib target only.
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum CommandOutput {
     /// No specific output value
@@ -42,6 +46,7 @@ pub enum SubCommand {
 }
 
 impl SubCommand {
+    #[allow(dead_code)] // entry point of the pm-publisher binary; unused by the lib target
     pub async fn call(&self, network: &str) -> anyhow::Result<CommandOutput> {
         let crate_path = PathBuf::new();
         let store_config = crate_path.join(STORE_FILENAME);

--- a/crates/cli/publisher/src/commands/publish.rs
+++ b/crates/cli/publisher/src/commands/publish.rs
@@ -6,8 +6,8 @@ use miden_client::{
 use miden_standards::code_builder::CodeBuilder;
 
 use miden_client::account::AccountId;
-use pm_accounts::{publisher::get_publisher_component_library, utils::word_to_masm};
 use miden_client::Felt;
+use pm_accounts::{publisher::get_publisher_component_library, utils::word_to_masm};
 use pm_utils_cli::{get_publisher_id, PRAGMA_ACCOUNTS_STORAGE_FILE};
 
 #[derive(clap::Parser, Debug, Clone)]
@@ -62,12 +62,16 @@ impl PublishCmd {
 
         let parts: Vec<&str> = self.faucet_id.split(':').collect();
         if parts.len() != 2 {
-            return Err(anyhow::anyhow!("Invalid faucet_id format. Expected PREFIX:SUFFIX (e.g., 1:0)"));
+            return Err(anyhow::anyhow!(
+                "Invalid faucet_id format. Expected PREFIX:SUFFIX (e.g., 1:0)"
+            ));
         }
-        
-        let prefix = parts[0].parse::<u64>()
+
+        let prefix = parts[0]
+            .parse::<u64>()
             .map_err(|_| anyhow::anyhow!("Invalid faucet_id prefix: {}", parts[0]))?;
-        let suffix = parts[1].parse::<u64>()
+        let suffix = parts[1]
+            .parse::<u64>()
             .map_err(|_| anyhow::anyhow!("Invalid faucet_id suffix: {}", parts[1]))?;
 
         let entry_as_word: Word = [
@@ -75,8 +79,9 @@ impl PublishCmd {
             Felt::new(self.price),
             Felt::new(self.decimals as u64),
             Felt::new(self.timestamp),
-        ].into();
-        
+        ]
+        .into();
+
         let tx_script_code = format!(
             "
                 use publisher_component::publisher_module

--- a/crates/cli/publisher/src/commands/publish_batch.rs
+++ b/crates/cli/publisher/src/commands/publish_batch.rs
@@ -49,6 +49,9 @@ impl PublishBatchCmd {
     /// - Any entry string cannot be parsed
     /// - The transaction script compilation fails
     /// - The transaction submission fails
+    // Used by the binary via SubCommand::call; the lib uses the free
+    // `publish_batch` fn, so this method is dead code in the lib target only.
+    #[allow(dead_code)]
     pub async fn call(
         &self,
         client: &mut Client<FilesystemKeyStore>,

--- a/crates/cli/publisher/src/commands/publish_batch.rs
+++ b/crates/cli/publisher/src/commands/publish_batch.rs
@@ -6,12 +6,14 @@ use miden_client::{
 use miden_standards::code_builder::CodeBuilder;
 
 use miden_client::account::AccountId;
-use pm_accounts::{publisher::get_publisher_component_library, utils::word_to_masm};
 use miden_client::Felt;
+use pm_accounts::{publisher::get_publisher_component_library, utils::word_to_masm};
 use pm_utils_cli::{get_publisher_id, PRAGMA_ACCOUNTS_STORAGE_FILE};
 
 #[derive(clap::Parser, Debug, Clone)]
-#[clap(about = "Publish multiple entries in a single transaction (Callable by the publisher itself)")]
+#[clap(
+    about = "Publish multiple entries in a single transaction (Callable by the publisher itself)"
+)]
 pub struct PublishBatchCmd {
     /// Faucet IDs to publish in format: "1:0:98000000000:6:1234567890 2:0:1900000000:6:1234567890"
     /// Format per entry: FAUCET_ID:PRICE:DECIMALS:TIMESTAMP (e.g., "1:0" for BTC/USD)
@@ -78,7 +80,13 @@ impl PublishBatchCmd {
                 .map_err(|e| anyhow::anyhow!("Invalid timestamp '{}': {}", parts[4], e))?;
             typed_entries.push((format!("{}:{}", prefix, suffix), price, decimals, timestamp));
         }
-        publish_batch(client, network, &typed_entries, self.publisher_id.as_deref()).await
+        publish_batch(
+            client,
+            network,
+            &typed_entries,
+            self.publisher_id.as_deref(),
+        )
+        .await
     }
 }
 
@@ -179,6 +187,9 @@ pub async fn publish_batch(
         .await
         .map_err(|e| anyhow::anyhow!("Error while submitting transaction: {e:?}"))?;
 
-    println!("✓ Batch publish successful! ({} entries)", entries_data.len());
+    println!(
+        "✓ Batch publish successful! ({} entries)",
+        entries_data.len()
+    );
     Ok(())
 }

--- a/crates/cli/publisher/src/commands/sync.rs
+++ b/crates/cli/publisher/src/commands/sync.rs
@@ -7,10 +7,7 @@ use miden_client::{keystore::FilesystemKeyStore, Client};
 pub struct SyncCmd {}
 
 impl SyncCmd {
-    pub async fn call(
-        &self,
-        client: &mut Client<FilesystemKeyStore>,
-    ) -> anyhow::Result<()> {
+    pub async fn call(&self, client: &mut Client<FilesystemKeyStore>) -> anyhow::Result<()> {
         let new_details = client
             .sync_state()
             .await

--- a/crates/cli/publisher/src/commands/sync.rs
+++ b/crates/cli/publisher/src/commands/sync.rs
@@ -11,7 +11,7 @@ impl SyncCmd {
         let new_details = client
             .sync_state()
             .await
-            .map_err(|e| anyhow::anyhow!("Could not sync state: {}", e.to_string()))?;
+            .map_err(|e| anyhow::anyhow!("Could not sync state: {}", e))?;
         println!("🔁 Sync successful!\n");
 
         println!("State synced to block {}", new_details.block_num);

--- a/crates/cli/publisher/src/lib.rs
+++ b/crates/cli/publisher/src/lib.rs
@@ -32,7 +32,6 @@ fn rt() -> &'static Runtime {
     })
 }
 
-
 /// Initialize publisher and return a client handle
 #[pyfunction]
 #[pyo3(name = "init")]
@@ -202,8 +201,9 @@ fn py_import_account(
         let network_str = network.as_deref().unwrap_or("testnet");
         let mut client = setup_client(network_str, store_config, keystore_path).await?;
 
-        let id = AccountId::from_hex(&account_id)
-            .map_err(|e| PyValueError::new_err(format!("Invalid account_id '{}': {}", account_id, e)))?;
+        let id = AccountId::from_hex(&account_id).map_err(|e| {
+            PyValueError::new_err(format!("Invalid account_id '{}': {}", account_id, e))
+        })?;
 
         client
             .import_account_by_id(id)
@@ -278,9 +278,7 @@ async fn setup_client(
             println!("Initializing local client");
             setup_local_client(Some(store_config), keystore_path)
                 .await
-                .map_err(|e| {
-                    PyValueError::new_err(format!("Failed to setup local client: {}", e))
-                })
+                .map_err(|e| PyValueError::new_err(format!("Failed to setup local client: {}", e)))
         }
         other => {
             return Err(PyValueError::new_err(format!(

--- a/crates/cli/publisher/src/lib.rs
+++ b/crates/cli/publisher/src/lib.rs
@@ -281,10 +281,10 @@ async fn setup_client(
                 .map_err(|e| PyValueError::new_err(format!("Failed to setup local client: {}", e)))
         }
         other => {
-            return Err(PyValueError::new_err(format!(
+            Err(PyValueError::new_err(format!(
                 "Unknown network '{}'. Must be 'local', 'devnet' or 'testnet'",
                 other
-            )));
+            )))
         }
     }
 }

--- a/crates/cli/publisher/src/lib.rs
+++ b/crates/cli/publisher/src/lib.rs
@@ -280,12 +280,10 @@ async fn setup_client(
                 .await
                 .map_err(|e| PyValueError::new_err(format!("Failed to setup local client: {}", e)))
         }
-        other => {
-            Err(PyValueError::new_err(format!(
-                "Unknown network '{}'. Must be 'local', 'devnet' or 'testnet'",
-                other
-            )))
-        }
+        other => Err(PyValueError::new_err(format!(
+            "Unknown network '{}'. Must be 'local', 'devnet' or 'testnet'",
+            other
+        ))),
     }
 }
 

--- a/crates/cli/utils/src/client.rs
+++ b/crates/cli/utils/src/client.rs
@@ -34,7 +34,7 @@ pub async fn setup_local_client(
         Some(p) => p,
         None => {
             let exec_dir = PathBuf::new();
-            
+
             exec_dir.join(STORE_FILENAME)
         }
     };
@@ -94,7 +94,7 @@ pub async fn setup_devnet_client(
         Some(p) => p,
         None => {
             let exec_dir = PathBuf::new();
-            
+
             exec_dir.join(STORE_FILENAME)
         }
     };
@@ -160,7 +160,7 @@ pub async fn setup_testnet_client(
         Some(p) => p,
         None => {
             let exec_dir = PathBuf::new();
-            
+
             exec_dir.join(STORE_FILENAME)
         }
     };

--- a/crates/cli/utils/src/client.rs
+++ b/crates/cli/utils/src/client.rs
@@ -34,8 +34,8 @@ pub async fn setup_local_client(
         Some(p) => p,
         None => {
             let exec_dir = PathBuf::new();
-            let p = exec_dir.join(STORE_FILENAME);
-            p
+            
+            exec_dir.join(STORE_FILENAME)
         }
     };
 
@@ -59,7 +59,7 @@ pub async fn setup_local_client(
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).ok();
     }
-    let store = SqliteStore::new(path.try_into().expect("Path should be valid"))
+    let store = SqliteStore::new(path)
         .await
         .map_err(ClientError::StoreError)?;
     let arc_store = Arc::new(store);
@@ -94,8 +94,8 @@ pub async fn setup_devnet_client(
         Some(p) => p,
         None => {
             let exec_dir = PathBuf::new();
-            let p = exec_dir.join(STORE_FILENAME);
-            p
+            
+            exec_dir.join(STORE_FILENAME)
         }
     };
 
@@ -121,7 +121,7 @@ pub async fn setup_devnet_client(
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).ok();
     }
-    let store = SqliteStore::new(path.try_into().expect("Path should be valid"))
+    let store = SqliteStore::new(path)
         .await
         .map_err(ClientError::StoreError)?;
     let arc_store = Arc::new(store);
@@ -160,8 +160,8 @@ pub async fn setup_testnet_client(
         Some(p) => p,
         None => {
             let exec_dir = PathBuf::new();
-            let p = exec_dir.join(STORE_FILENAME);
-            p
+            
+            exec_dir.join(STORE_FILENAME)
         }
     };
 
@@ -187,7 +187,7 @@ pub async fn setup_testnet_client(
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).ok();
     }
-    let store = SqliteStore::new(path.try_into().expect("Path must be valid"))
+    let store = SqliteStore::new(path)
         .await
         .map_err(ClientError::StoreError)?;
     let arc_store = Arc::new(store);

--- a/crates/cli/utils/src/client.rs
+++ b/crates/cli/utils/src/client.rs
@@ -217,7 +217,10 @@ where
     let account = AccountBuilder::new(init_seed)
         .account_type(AccountType::RegularAccountImmutableCode)
         .storage_mode(storage_mode)
-        .with_component(AuthSingleSig::new(key_pair.public_key().to_commitment().into(), AuthScheme::Falcon512Poseidon2))
+        .with_component(AuthSingleSig::new(
+            key_pair.public_key().to_commitment().into(),
+            AuthScheme::Falcon512Poseidon2,
+        ))
         .with_component(BasicWallet)
         .build()
         .unwrap();

--- a/crates/cli/utils/src/network.rs
+++ b/crates/cli/utils/src/network.rs
@@ -11,7 +11,7 @@ pub fn get_networks_config(storage_path: &Path) -> Result<Value> {
     let storage = JsonStorage::new(storage_path_str)?;
 
     match storage.get_key("networks") {
-        Some(json_str) => serde_json::from_str::<Value>(&json_str)
+        Some(json_str) => serde_json::from_str::<Value>(json_str)
             .context("Failed to parse networks configuration"),
         None => Err(anyhow::anyhow!(
             "No networks configuration found in storage"
@@ -77,14 +77,14 @@ pub fn set_account_id(
     let mut config = read_config_file(storage_path)?;
 
     // Ensure networks exists and is an object
-    if !config.get("networks").map_or(false, |v| v.is_object()) {
+    if !config.get("networks").is_some_and(|v| v.is_object()) {
         config["networks"] = json!({});
     }
 
     // Ensure the specific network exists and is an object
     if !config["networks"]
         .get(network)
-        .map_or(false, |v| v.is_object())
+        .is_some_and(|v| v.is_object())
     {
         config["networks"][network] = json!({});
     }
@@ -136,14 +136,14 @@ pub fn add_publisher_id(storage_path: &Path, network: &str, account_id: &Account
     let mut config = read_config_file(storage_path)?;
 
     // Ensure networks exists and is an object
-    if !config.get("networks").map_or(false, |v| v.is_object()) {
+    if !config.get("networks").is_some_and(|v| v.is_object()) {
         config["networks"] = json!({});
     }
 
     // Ensure the specific network exists and is an object
     if !config["networks"]
         .get(network)
-        .map_or(false, |v| v.is_object())
+        .is_some_and(|v| v.is_object())
     {
         config["networks"][network] = json!({});
     }

--- a/crates/types/src/pair.rs
+++ b/crates/types/src/pair.rs
@@ -381,7 +381,7 @@ mod tests {
         let pair_string = long_pair.to_string();
         assert_eq!(pair_string.len(), 16, "Verify string length is 16");
 
-        let felts_needed = (pair_string.len() + 7) / 8; // Ceiling division
+        let felts_needed = pair_string.len().div_ceil(8); // Ceiling division
         assert_eq!(felts_needed, 2, "Should require 2 Felts");
 
         let result = long_pair.try_to_decimal_felt_array::<1>();
@@ -420,7 +420,7 @@ mod tests {
             long_string,
             long_string.len()
         );
-        let felts_needed = (long_string.len() + 7) / 8; // Ceiling division
+        let felts_needed = long_string.len().div_ceil(8); // Ceiling division
         assert!(felts_needed > 2, "Test needs a pair requiring >2 Felts");
 
         // Test failure with insufficient size array

--- a/examples/consume-price/src/main.rs
+++ b/examples/consume-price/src/main.rs
@@ -1,9 +1,7 @@
 use anyhow::{Context, Result};
 use miden_client::{
-    account::AccountId,
-    rpc::domain::account::AccountStorageRequirements,
-    transaction::ForeignAccount,
-    Felt, Word, ZERO,
+    account::AccountId, rpc::domain::account::AccountStorageRequirements,
+    transaction::ForeignAccount, Felt, Word, ZERO,
 };
 use miden_protocol::account::{StorageMapKey, StorageSlotName};
 use miden_protocol::vm::AdviceInputs;
@@ -118,7 +116,10 @@ async fn main() -> Result<()> {
             oracle_id,
             script,
             AdviceInputs::default(),
-            foreign_accounts.into_iter().map(|fa| (fa.account_id(), fa)).collect::<BTreeMap<_, _>>(),
+            foreign_accounts
+                .into_iter()
+                .map(|fa| (fa.account_id(), fa))
+                .collect::<BTreeMap<_, _>>(),
         )
         .await
         .map_err(|e| anyhow::anyhow!("execute_program failed: {e:?}"))?;


### PR DESCRIPTION
## Why
The `Build and Test` workflow had been **red on `main` for weeks**. It:
- built a **miden-node v0.8** Docker image (we run v0.14) → fails on `edition2024` vs the Dockerfile's pinned Cargo;
- then ran tests that no longer exist (`test_oracle_get_entry`, `test_oracle_get_median`, `test_publisher`) against the wrong port (`57291` vs node `57123`);
- used archived actions (`actions-rs/toolchain@v1`, `checkout@v3`).

Since the oracle tests now run **in-process via `miden_testing::MockChain`**, no external node is needed — the suite runs in ~7s with plain `cargo test`.

## What
Rewrites `.github/workflows/test.yml` into two parallel jobs on the pinned toolchain (`rust-toolchain.toml`, channel 1.93) with cargo caching:
- **Build & Test** — `cargo build --workspace --all-targets` + `cargo test --workspace` (covers the `examples/consume-price` member too).
- **Lint** — `cargo fmt --all --check` + `cargo clippy --workspace --all-targets -- -D warnings`.

To make the new gates green from day one:
- `cargo fmt --all` across the repo (formatting only; no MASM touched).
- Resolved **all** clippy warnings (`--fix` nits + dropped useless `PathBuf` conversions in `pm-utils-cli`; annotated the bin-only dispatch helpers `SubCommand::call` / `CommandOutput` / `PublishBatchCmd::call`, which are dead-code in the lib target since `commands/` is shared between the CLI binary and the pyo3 lib).

The deploy pipeline (`docker-build.yml`) is unchanged.

## Verified locally
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ (clean)
- `cargo build --workspace --all-targets` ✅
- `cargo test --workspace` ✅ (7 oracle MockChain tests + unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)