### PR TITLE
perf(publisher): remote prover + ECDSA auth (60-120s -> ~3s publish)

### DIFF
--- a/crates/accounts/src/publisher/mod.rs
+++ b/crates/accounts/src/publisher/mod.rs
@@ -8,7 +8,6 @@ use miden_client::{
         Account, AccountStorageMode, AccountType as ClientAccountType,
     },
     auth::AuthSecretKey,
-    crypto::rpo_falcon512::SecretKey,
     keystore::{FilesystemKeyStore, Keystore},
     Client, Word,
 };
@@ -121,17 +120,16 @@ impl<'a> PublisherAccountBuilder<'a> {
 
     pub async fn build(self) -> (Account, Word) {
         let client = self.client.expect("build must have a Miden Client!");
-        let client_rng = client.rng();
-        let private_key = SecretKey::with_rng(client_rng);
-        let public_key = private_key.public_key();
-
+        // ECDSA (secp256k1/keccak) auth: far fewer VM cycles than Falcon512 to
+        // verify in-circuit, which directly shrinks the publish tx proof.
+        let auth_key = AuthSecretKey::new_ecdsa_k256_keccak();
         let auth_component = AuthSingleSig::new(
-            public_key.to_commitment().into(),
-            AuthScheme::Falcon512Poseidon2,
+            auth_key.public_key().to_commitment(),
+            AuthScheme::EcdsaK256Keccak,
         );
 
         let publisher_component: AccountComponent = get_publisher_component();
-        let from_seed = client_rng.random();
+        let from_seed = client.rng().random();
         let account_type: String = self.account_type.to_string();
         let client_account_type: ClientAccountType = account_type.parse().unwrap();
         let account = AccountBuilder::new(from_seed)
@@ -145,13 +143,7 @@ impl<'a> PublisherAccountBuilder<'a> {
 
         client.add_account(&account, true).await.unwrap();
         let keystore = FilesystemKeyStore::new(self.keystore_path.into()).unwrap();
-        keystore
-            .add_key(
-                &AuthSecretKey::Falcon512Poseidon2(private_key),
-                account.id(),
-            )
-            .await
-            .unwrap();
+        keystore.add_key(&auth_key, account.id()).await.unwrap();
 
         (account, account_seed)
     }

--- a/crates/cli/utils/src/client.rs
+++ b/crates/cli/utils/src/client.rs
@@ -1,4 +1,5 @@
 use crate::STORE_FILENAME;
+use miden_client::grpc_support::{DEVNET_PROVER_ENDPOINT, TESTNET_PROVER_ENDPOINT};
 use miden_client::{
     account::{
         component::{AuthScheme, AuthSingleSig, BasicWallet},
@@ -8,50 +9,41 @@ use miden_client::{
     crypto::{rpo_falcon512::SecretKey, RandomCoin},
     keystore::{FilesystemKeyStore, Keystore},
     rpc::{Endpoint, GrpcClient},
-    Client, ClientError, Felt, Word,
+    Client, ClientError, Felt, RemoteTransactionProver, Word,
 };
 use miden_client_sqlite_store::SqliteStore;
-use rand::{Rng, RngCore};
+use rand::RngCore;
 use std::{fs, path::PathBuf, sync::Arc};
 
 // Client Setup
 // ================================================================================================
 
-pub async fn setup_local_client(
+// Bounds every node RPC call, including SubmitProvenTx. 10s was too tight for
+// the heavier first submit after a cold start (account deploy) — observed real
+// >10s submits on testnet. 60s gives headroom and is itself bounded by the
+// SDK-side 180s publish_batch timeout.
+const RPC_TIMEOUT_MS: u64 = 60_000;
+
+/// Build a Miden client for the given network endpoint.
+///
+/// When `prover_endpoint` is `Some`, transaction proving is delegated to
+/// Miden's hosted remote prover. Proving a `publish_batch` tx in-process
+/// (the default `LocalTransactionProver`) takes 60-120s and >4Gi RSS on the
+/// publisher pod, so testnet/devnet offload it; `local` keeps local proving
+/// since a local node has no hosted prover.
+async fn setup_client(
+    endpoint: Endpoint,
+    prover_endpoint: Option<&str>,
     path: Option<PathBuf>,
     keystore_path: Option<String>,
 ) -> Result<Client<FilesystemKeyStore>, ClientError> {
-    let endpoint = Endpoint::localhost();
-    let timeout_ms = 10_000;
-
-    let rpc_api = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
+    let rpc_api = Arc::new(GrpcClient::new(&endpoint, RPC_TIMEOUT_MS));
 
     let coin_seed: [u64; 4] = rand::random();
-
     let rng = Box::new(RandomCoin::new(coin_seed.map(Felt::new).into()));
 
-    let path = match path {
-        Some(p) => p,
-        None => {
-            let exec_dir = PathBuf::new();
-
-            exec_dir.join(STORE_FILENAME)
-        }
-    };
-
-    let keystore_path_str = keystore_path.unwrap_or_else(|| {
-        let mut current_dir = std::env::current_dir().expect("Failed to get current directory");
-        loop {
-            if current_dir.join("Cargo.toml").exists() {
-                return current_dir.join("keystore").to_string_lossy().to_string();
-            }
-            if let Some(parent) = current_dir.parent() {
-                current_dir = parent.to_path_buf();
-            } else {
-                return "./keystore".to_string();
-            }
-        }
-    });
+    let path = path.unwrap_or_else(|| PathBuf::new().join(STORE_FILENAME));
+    let keystore_path_str = keystore_path.unwrap_or_else(default_keystore_path);
     let keystore = FilesystemKeyStore::new(keystore_path_str.into())
         .unwrap()
         .into();
@@ -62,146 +54,69 @@ pub async fn setup_local_client(
     let store = SqliteStore::new(path)
         .await
         .map_err(ClientError::StoreError)?;
-    let arc_store = Arc::new(store);
 
-    let client = ClientBuilder::new()
+    let mut builder = ClientBuilder::new()
         .authenticator(keystore)
         .rpc(rpc_api)
         .rng(rng)
-        .store(arc_store)
-        .in_debug_mode(miden_client::DebugMode::Enabled)
-        .build()
-        .await?;
+        .store(Arc::new(store))
+        .in_debug_mode(miden_client::DebugMode::Enabled);
 
-    Ok(client)
+    if let Some(prover_url) = prover_endpoint {
+        builder = builder.prover(Arc::new(RemoteTransactionProver::new(
+            prover_url.to_string(),
+        )));
+    }
+
+    builder.build().await
+}
+
+/// Resolve the keystore directory by walking up to the project root
+/// (first ancestor containing a `Cargo.toml`), falling back to `./keystore`.
+fn default_keystore_path() -> String {
+    let mut current_dir = std::env::current_dir().expect("Failed to get current directory");
+    loop {
+        if current_dir.join("Cargo.toml").exists() {
+            return current_dir.join("keystore").to_string_lossy().to_string();
+        }
+        match current_dir.parent() {
+            Some(parent) => current_dir = parent.to_path_buf(),
+            None => return "./keystore".to_string(),
+        }
+    }
+}
+
+pub async fn setup_local_client(
+    path: Option<PathBuf>,
+    keystore_path: Option<String>,
+) -> Result<Client<FilesystemKeyStore>, ClientError> {
+    setup_client(Endpoint::localhost(), None, path, keystore_path).await
 }
 
 pub async fn setup_devnet_client(
     path: Option<PathBuf>,
     keystore_path: Option<String>,
 ) -> Result<Client<FilesystemKeyStore>, ClientError> {
-    // RPC endpoint and timeout
-    let endpoint = Endpoint::devnet();
-    let timeout_ms = 10_000;
-
-    let rpc_api = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
-
-    let coin_seed: [u64; 4] = rand::random();
-
-    let rng = Box::new(RandomCoin::new(coin_seed.map(Felt::new).into()));
-
-    let path = match path {
-        Some(p) => p,
-        None => {
-            let exec_dir = PathBuf::new();
-
-            exec_dir.join(STORE_FILENAME)
-        }
-    };
-
-    let keystore_path_str = keystore_path.unwrap_or_else(|| {
-        // Find the project root by looking for Cargo.toml
-        let mut current_dir = std::env::current_dir().expect("Failed to get current directory");
-        loop {
-            if current_dir.join("Cargo.toml").exists() {
-                return current_dir.join("keystore").to_string_lossy().to_string();
-            }
-            if let Some(parent) = current_dir.parent() {
-                current_dir = parent.to_path_buf();
-            } else {
-                // Fallback to relative path if we can't find project root
-                return "./keystore".to_string();
-            }
-        }
-    });
-    let keystore = FilesystemKeyStore::new(keystore_path_str.into())
-        .unwrap()
-        .into();
-
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).ok();
-    }
-    let store = SqliteStore::new(path)
-        .await
-        .map_err(ClientError::StoreError)?;
-    let arc_store = Arc::new(store);
-
-    let client = ClientBuilder::new()
-        .authenticator(keystore)
-        .rpc(rpc_api)
-        .rng(rng)
-        .store(arc_store)
-        .in_debug_mode(miden_client::DebugMode::Enabled)
-        .build()
-        .await?;
-
-    Ok(client)
+    setup_client(
+        Endpoint::devnet(),
+        Some(DEVNET_PROVER_ENDPOINT),
+        path,
+        keystore_path,
+    )
+    .await
 }
 
 pub async fn setup_testnet_client(
     storage_path: Option<PathBuf>,
     keystore_path: Option<String>,
 ) -> Result<Client<FilesystemKeyStore>, ClientError> {
-    // RPC endpoint and timeout
-    let endpoint = Endpoint::testnet();
-    let timeout_ms = 10_000;
-
-    // Build RPC client
-    let rpc_api = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
-
-    // Seed RNG
-    let mut seed_rng = rand::rng();
-    let coin_seed: [u64; 4] = seed_rng.random();
-
-    // Create random coin instance
-    let rng = Box::new(RandomCoin::new(coin_seed.map(Felt::new).into()));
-
-    let path = match storage_path {
-        Some(p) => p,
-        None => {
-            let exec_dir = PathBuf::new();
-
-            exec_dir.join(STORE_FILENAME)
-        }
-    };
-
-    let keystore_path_str = keystore_path.unwrap_or_else(|| {
-        // Find the project root by looking for Cargo.toml
-        let mut current_dir = std::env::current_dir().expect("Failed to get current directory");
-        loop {
-            if current_dir.join("Cargo.toml").exists() {
-                return current_dir.join("keystore").to_string_lossy().to_string();
-            }
-            if let Some(parent) = current_dir.parent() {
-                current_dir = parent.to_path_buf();
-            } else {
-                // Fallback to relative path if we can't find project root
-                return "./keystore".to_string();
-            }
-        }
-    });
-    let keystore = FilesystemKeyStore::new(keystore_path_str.into())
-        .unwrap()
-        .into();
-
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).ok();
-    }
-    let store = SqliteStore::new(path)
-        .await
-        .map_err(ClientError::StoreError)?;
-    let arc_store = Arc::new(store);
-
-    let client = ClientBuilder::new()
-        .authenticator(keystore)
-        .rpc(rpc_api)
-        .rng(rng)
-        .store(arc_store)
-        .in_debug_mode(miden_client::DebugMode::Enabled)
-        .build()
-        .await?;
-
-    Ok(client)
+    setup_client(
+        Endpoint::testnet(),
+        Some(TESTNET_PROVER_ENDPOINT),
+        storage_path,
+        keystore_path,
+    )
+    .await
 }
 
 pub async fn create_wallet<K>(


### PR DESCRIPTION
## What

Two independent latency wins for Miden price publishing, both validated end-to-end on testnet.

### 1. Delegate proving to Miden's hosted remote prover (`client.rs`)
The client was hand-built with `ClientBuilder::new()` and never set a prover, so it fell back to `LocalTransactionProver::default()` — in-process zkSTARK proving of a `publish_batch` tx took **60-120s and >4Gi RSS** on the publisher pod. Refactored the three duplicated `setup_*_client` fns into one helper that delegates proving to `tx-prover.{testnet,devnet}.miden.io` (local keeps local proving). Also bumped `RPC_TIMEOUT_MS` 10s→60s — the heavier cold-start `SubmitProvenTx` exceeded 10s on testnet.

### 2. Switch publisher account auth Falcon512 → ECDSA (`publisher/mod.rs`)
`EcdsaK256Keccak` verifies in far fewer VM cycles than Falcon512, shrinking the proof. 5-line change via `AuthSecretKey::new_ecdsa_k256_keccak()` (already in miden-protocol 0.14.4, no dep bump).

## Measured (testnet, release `pm-publisher-cli`, 5-pair `publish_batch`)

| Setup | Steady-state |
|---|---|
| Falcon512 + local proving (before) | 60-120s |
| Falcon512 + remote prover | ~4-5.5s |
| **ECDSA + remote prover** | **~2.7-3.9s** |

→ ~20-40× faster, proving off-pod.

## ⚠️ Rollout note
ECDSA auth is sealed into the account id — existing Falcon publisher accounts are **not** upgraded in place. To benefit in prod, the publisher must be re-deployed in ECDSA and re-registered with the oracle (+ update SDK config / K8s secret / devops with the new publisher id). The prod oracle (Immutable) is untouched. Not done in this PR.

## Test
- `cargo build/clippy/fmt` green.
- Manual testnet runs: fresh ECDSA publisher init + 5 timed `publish_batch` (cold + steady-state), all `✓ Batch publish successful!`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)