### PR TITLE
chore: bump to 0.1.0-alpha.5 (pm-publisher release)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2982,7 +2982,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pm-accounts"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.5"
 dependencies = [
  "anyhow",
  "miden-client",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "pm-oracle-cli"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3030,7 +3030,7 @@ dependencies = [
 
 [[package]]
 name = "pm-publisher-cli"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "pm-types"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.5"
 dependencies = [
  "anyhow",
  "miden-client",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "pm-utils-cli"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 unsafe_code = "forbid"
 
 [workspace.package]
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.5"
 authors = ["Pragma <https://github.com/astraly-labs>"]
 homepage = "https://www.pragma.build/"
 edition = "2021"


### PR DESCRIPTION
Bumps the workspace version `0.1.0-alpha.1` → `0.1.0-alpha.5` so we can cut the next `pm-publisher` wheel on PyPI (latest published is `0.1.0a4`).

The wheel will carry the latency work from #59:
- delegated proving to Miden's hosted remote prover (60-120s → ~4-5s)
- publisher account auth Falcon512 → ECDSA (~3s)

After merge, tagging `py-v0.1.0a5` triggers `publish-pypi.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)