### PR TITLE
chore: bump pyproject to 0.1.0-alpha.5 (fixes effective PyPI version)

### DIFF
--- a/crates/cli/publisher/pyproject.toml
+++ b/crates/cli/publisher/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pm-publisher"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 description = "Python bindings for Pragma Miden Publisher CLI"
 authors = [{ name = "Pragma", email = "jordy@pragma.build" }]
 requires-python = ">=3.7"


### PR DESCRIPTION
Follow-up to #60. maturin publishes the version from `crates/cli/publisher/pyproject.toml` `[project].version` (verified: tag `py-v0.1.4` had pyproject `0.1.0-alpha.4` and published `0.1.0a4`, while Cargo.toml was still `0.1.0-alpha.1`). #60 only bumped Cargo.toml, so the effective PyPI version was still `a4`.

This bumps pyproject `0.1.0-alpha.4` → `0.1.0-alpha.5` so tagging `py-v0.1.5` publishes `0.1.0a5` (carrying the remote-prover + ECDSA work from #59).

🤖 Generated with [Claude Code](https://claude.com/claude-code)