### PR TITLE
docs: point oracle/publisher addresses at the v2 oracle + ECDSA publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,8 @@
 
 | Role       | Account ID                           | Explorer |
 |------------|--------------------------------------|----------|
-| Oracle     | `0xec7e450b91bf690015ad79573689f1`  | [view](https://testnet.midenscan.com/account/0xec7e450b91bf690015ad79573689f1) |
-| Publisher1 | `0xaa9c9ad8583c3b0064eff7356152bd`  | [view](https://testnet.midenscan.com/account/0xaa9c9ad8583c3b0064eff7356152bd) |
-| Publisher2 | `0x39c45ece7de124002191469753074f`  | [view](https://testnet.midenscan.com/account/0x39c45ece7de124002191469753074f) |
-| Publisher3 | `0x022c8db22d56b1000643d54faf7487`  | [view](https://testnet.midenscan.com/account/0x022c8db22d56b1000643d54faf7487) |
+| Oracle     | `0xcaf3856aedfa4b106d59998789348f`  | [view](https://testnet.midenscan.com/account/mtst1ar908pt2ahaykyrdtxvc0zf53uujtu0c) |
+| Publisher  | `0xb82114f2a59810006d0410a6c44e46`  | [view](https://testnet.midenscan.com/account/mtst1azuzz98j5kvpqqrdqsg2d3zwgcx394vh) |
 
 > Addresses change between testnet iterations. This table is the source of truth.
 

--- a/examples/consume-price/README.md
+++ b/examples/consume-price/README.md
@@ -15,10 +15,8 @@ Expected output:
 ```
 Syncing with testnet...
 Latest block: 651945
-Registered publishers: 3
-Imported publisher: 0xaa9c9ad8583c3b0064eff7356152bd
-Imported publisher: 0x39c45ece7de124002191469753074f
-Imported publisher: 0x022c8db22d56b1000643d54faf7487
+Registered publishers: 1
+Imported publisher: 0xb82114f2a59810006d0410a6c44e46
 BTC/USD: $76316.00  (raw: 76316000000, 6 decimals)
 ```
 

--- a/examples/consume-price/src/main.rs
+++ b/examples/consume-price/src/main.rs
@@ -11,7 +11,7 @@ use pm_utils_cli::setup_testnet_client;
 use std::collections::BTreeMap;
 
 // ── Pragma Miden testnet oracle ───────────────────────────────────────────────
-const ORACLE_ID: &str = "0xec7e450b91bf690015ad79573689f1";
+const ORACLE_ID: &str = "0xcaf3856aedfa4b106d59998789348f";
 
 // ── Asset: BTC/USD (faucet_id "1:0") ─────────────────────────────────────────
 const PAIR_PREFIX: u64 = 1;

--- a/oracle-explorer/app/page.tsx
+++ b/oracle-explorer/app/page.tsx
@@ -19,8 +19,8 @@ const FAUCET_IDS = [
 ];
 
 const CONTRACTS = [
-  { name: "Oracle", address: "mtst1argwzwzwyxnr2qpfmqqj366ugsax2t3x", url: "https://testnet.midenscan.com/account/mtst1argwzwzwyxnr2qpfmqqj366ugsax2t3x" },
-  { name: "Publisher", address: "mtst1aqhn4fnd8x8duqr9y4ku23qqwyzdndw3", url: "https://testnet.midenscan.com/account/mtst1aqhn4fnd8x8duqr9y4ku23qqwyzdndw3" },
+  { name: "Oracle", address: "mtst1ar908pt2ahaykyrdtxvc0zf53uujtu0c", url: "https://testnet.midenscan.com/account/mtst1ar908pt2ahaykyrdtxvc0zf53uujtu0c" },
+  { name: "Publisher", address: "mtst1azuzz98j5kvpqqrdqsg2d3zwgcx394vh", url: "https://testnet.midenscan.com/account/mtst1azuzz98j5kvpqqrdqsg2d3zwgcx394vh" },
 ];
 
 const PUBLISHER_STEPS = [


### PR DESCRIPTION
Rotated to the new **v2 oracle** `0xcaf3856aedfa4b106d59998789348f` and the **ECDSA publisher** `0xb82114f2a59810006d0410a6c44e46`. Updates the hardcoded/stale references found by sweeping the repo's docs + code:

- `oracle-explorer/app/page.tsx` — `CONTRACTS` displayed addresses + Midenscan links (bech32).
- `README.md` — testnet account table (now a single publisher).
- `examples/consume-price/src/main.rs` — `ORACLE_ID` const.
- `examples/consume-price/README.md` — sample output (1 publisher).

Note: the explorer's **median data already follows the configured oracle** (`route.ts` runs `pm-oracle-cli median-batch` against the workspace config, which is the `miden-oracle-config-pragma` secret) — so the live prices switch via the secret, not code. These were the only places the old addresses were baked in. `.demo-workspaces/*` left untouched (local demo fixtures, not prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)