### PR TITLE
perf(publisher): reuse Miden client across pyo3 calls + debug mode off by default

### DIFF
--- a/crates/cli/publisher/src/lib.rs
+++ b/crates/cli/publisher/src/lib.rs
@@ -2,9 +2,11 @@ use miden_client::account::AccountId;
 use miden_client::{keystore::FilesystemKeyStore, Client};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::OnceLock;
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use tokio::runtime::{Builder, Runtime};
+use tokio::sync::Mutex as AsyncMutex;
 mod commands;
 use crate::commands::{
     entry::EntryCmd, get_entry::GetEntryCmd, init::InitCmd, publish::PublishCmd,
@@ -32,6 +34,36 @@ fn rt() -> &'static Runtime {
     })
 }
 
+/// Cache of Miden clients keyed by (network, store path, keystore path), so we
+/// reuse one client — and its open SQLite store + RPC channel — across pyo3
+/// calls instead of rebuilding it on every call. The long-running price-pusher
+/// publishes every few seconds, so rebuilding a client each time (reopening the
+/// store, re-logging "Initializing testnet client") was pure overhead.
+type CachedClient = Arc<AsyncMutex<Client<FilesystemKeyStore>>>;
+static CLIENTS: OnceLock<StdMutex<HashMap<String, CachedClient>>> = OnceLock::new();
+
+async fn cached_client(
+    network: &str,
+    store_config: PathBuf,
+    keystore_path: Option<String>,
+) -> PyResult<CachedClient> {
+    let key = format!(
+        "{network}|{}|{}",
+        store_config.to_string_lossy(),
+        keystore_path.as_deref().unwrap_or("")
+    );
+    let cache = CLIENTS.get_or_init(|| StdMutex::new(HashMap::new()));
+    if let Some(client) = cache.lock().unwrap().get(&key) {
+        return Ok(client.clone());
+    }
+    // Build outside the lock (setup is async); if another call raced us, keep
+    // the first client that made it into the map.
+    let client = Arc::new(AsyncMutex::new(
+        setup_client(network, store_config, keystore_path).await?,
+    ));
+    Ok(cache.lock().unwrap().entry(key).or_insert(client).clone())
+}
+
 /// Initialize publisher and return a client handle
 #[pyfunction]
 #[pyo3(name = "init")]
@@ -47,7 +79,8 @@ fn py_init(
 
         // Use appropriate client setup based on network parameter
         let network_str = network.as_deref().unwrap_or("testnet");
-        let mut client = setup_client(network_str, store_config, keystore_path).await?;
+        let client_arc = cached_client(network_str, store_config, keystore_path).await?;
+        let mut client = client_arc.lock().await;
 
         let cmd = InitCmd {
             oracle_id: Some(oracle_id),
@@ -79,7 +112,8 @@ fn py_publish(
 
         let network_str = network.as_deref().unwrap_or("testnet");
 
-        let mut client = setup_client(network_str, store_config, keystore_path).await?;
+        let client_arc = cached_client(network_str, store_config, keystore_path).await?;
+        let mut client = client_arc.lock().await;
 
         let cmd = PublishCmd {
             faucet_id,
@@ -112,7 +146,8 @@ fn py_get_entry(
 
         let network_str = network.as_deref().unwrap_or("testnet");
 
-        let mut client = setup_client(network_str, store_config, keystore_path).await?;
+        let client_arc = cached_client(network_str, store_config, keystore_path).await?;
+        let mut client = client_arc.lock().await;
 
         let cmd = GetEntryCmd { faucet_id };
         let entry = cmd
@@ -144,7 +179,8 @@ fn py_entry(
 
         let network_str = network.as_deref().unwrap_or("testnet");
 
-        let mut client = setup_client(network_str, store_config, keystore_path).await?;
+        let client_arc = cached_client(network_str, store_config, keystore_path).await?;
+        let mut client = client_arc.lock().await;
 
         let cmd = EntryCmd { faucet_id };
         cmd.call(&mut client, network_str)
@@ -173,7 +209,8 @@ fn py_publish_batch(
     rt().block_on(async {
         let store_config = get_store_config(storage_path);
         let network_str = network.as_deref().unwrap_or("testnet");
-        let mut client = setup_client(network_str, store_config, keystore_path).await?;
+        let client_arc = cached_client(network_str, store_config, keystore_path).await?;
+        let mut client = client_arc.lock().await;
 
         do_publish_batch(&mut client, network_str, &entries, None)
             .await
@@ -199,7 +236,8 @@ fn py_import_account(
     rt().block_on(async {
         let store_config = get_store_config(storage_path);
         let network_str = network.as_deref().unwrap_or("testnet");
-        let mut client = setup_client(network_str, store_config, keystore_path).await?;
+        let client_arc = cached_client(network_str, store_config, keystore_path).await?;
+        let mut client = client_arc.lock().await;
 
         let id = AccountId::from_hex(&account_id).map_err(|e| {
             PyValueError::new_err(format!("Invalid account_id '{}': {}", account_id, e))
@@ -228,7 +266,8 @@ fn py_sync(
         let network_str = network.as_deref().unwrap_or("testnet");
 
         // Use appropriate client setup based on network parameter
-        let mut client = setup_client(network_str, store_config, keystore_path).await?;
+        let client_arc = cached_client(network_str, store_config, keystore_path).await?;
+        let mut client = client_arc.lock().await;
 
         let cmd = SyncCmd {};
         cmd.call(&mut client)

--- a/crates/cli/utils/src/client.rs
+++ b/crates/cli/utils/src/client.rs
@@ -24,6 +24,17 @@ use std::{fs, path::PathBuf, sync::Arc};
 // SDK-side 180s publish_batch timeout.
 const RPC_TIMEOUT_MS: u64 = 60_000;
 
+/// Debug mode is off by default (it makes the assembler try to load MASM
+/// sources for richer traces — which logs `failed to load MASM sources` in
+/// the deployed wheel and adds execution overhead). Set `PM_MIDEN_DEBUG=1`
+/// to re-enable it for development (e.g. to get `debug.stack` output).
+fn debug_mode() -> miden_client::DebugMode {
+    match std::env::var("PM_MIDEN_DEBUG").as_deref() {
+        Ok("1") | Ok("true") | Ok("TRUE") => miden_client::DebugMode::Enabled,
+        _ => miden_client::DebugMode::Disabled,
+    }
+}
+
 /// Build a Miden client for the given network endpoint.
 ///
 /// When `prover_endpoint` is `Some`, transaction proving is delegated to
@@ -60,7 +71,7 @@ async fn setup_client(
         .rpc(rpc_api)
         .rng(rng)
         .store(Arc::new(store))
-        .in_debug_mode(miden_client::DebugMode::Enabled);
+        .in_debug_mode(debug_mode());
 
     if let Some(prover_url) = prover_endpoint {
         builder = builder.prover(Arc::new(RemoteTransactionProver::new(


### PR DESCRIPTION
Two cleanups for the long-running price-pusher embedder (it now publishes to Miden every few seconds via the decoupled loop).

### 1. Reuse the Miden client across pyo3 calls
Every `pm_publisher.*` call rebuilt a fresh `Client` (reopening the SQLite store, reconnecting, re-logging `Initializing testnet client`). Now clients are cached in a process-global `HashMap<(network, store, keystore), Arc<tokio::sync::Mutex<Client>>>` and reused. Each call locks the shared client instead of constructing a new one.

### 2. `in_debug_mode` off by default
Debug mode makes the assembler load MASM sources for richer traces — which logs `failed to load MASM sources into source manager` on every publish in the deployed wheel (the source dir isn't shipped) and adds overhead. Now off by default; set `PM_MIDEN_DEBUG=1` to re-enable for development (e.g. `debug.stack` output). **No MASM `debug.stack` statements are touched.**

## Test
- `cargo build/clippy/fmt` green (compiling confirms `Client: Send + Sync`, required for the cache static).
- Manual testnet publish works with debug off and with `PM_MIDEN_DEBUG=1`.
- The cache benefit (no repeated `Initializing testnet client`) only shows in the long-running pyo3 embedder, not the one-shot CLI binary.

Ships in the next `pm-publisher` wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)