### PR TITLE
feat(publisher): set a transaction expiration delta in the publish script

### DIFF
--- a/crates/cli/publisher/src/commands/publish_batch.rs
+++ b/crates/cli/publisher/src/commands/publish_batch.rs
@@ -160,16 +160,26 @@ pub async fn publish_batch(
         ));
     }
 
+    // Expire the tx after a bounded number of blocks if it isn't committed in
+    // time, so a stalled publish dies cleanly node-side instead of lingering
+    // and diverging the local account state (a custom-script tx must set this
+    // inside the script — the request builder rejects it otherwise). Must be
+    // 1..=65535; kept under the client's tx_discard_delta (20) so node and
+    // client agree on when a tx is dead.
+    const EXPIRATION_BLOCK_DELTA: u16 = 16;
+
     let tx_script_code = format!(
         "
             use publisher_component::publisher_module
             use miden::core::sys
 
             begin
+                push.{expiration} exec.::miden::protocol::tx::update_expiration_block_delta
                 {publish_calls}
                 exec.sys::truncate_stack
             end
         ",
+        expiration = EXPIRATION_BLOCK_DELTA,
         publish_calls = publish_calls
     );
 


### PR DESCRIPTION
Publisher txs had **no expiration**. For a custom-script tx the expiry can't be set via the request builder (it's rejected), so it must be set **inside the script** — per Miden's suggestion. Without it, a tx that stalls in the mempool lingers; the client then discards it as stale (`tx_discard_delta` default 20 blocks), which diverges the local account from chain and wedges subsequent publishes (`IncorrectAccountInitialCommitment`).

With an explicit expiry, the node drops a stalled tx **deterministically** at a known block, so client and node agree it's dead and the next publish proceeds with fresh data (better for an oracle than a stale tx committing late).

## Change
Adds to the `publish_batch` tx script:
```
push.{EXPIRATION_BLOCK_DELTA} exec.::miden::protocol::tx::update_expiration_block_delta
```
`EXPIRATION_BLOCK_DELTA = 16` blocks — kept under the client's 20-block discard window so the node expires before the client discards. Tunable; pending Miden's recommended value for our cadence.

## Test
- `cargo build/clippy/fmt` green; the script **assembles** (the kernel proc resolves) and a test submit shows the **node enforces the expiry** (a tx built on a stale reference block is cleanly rejected as expired). Happy-path publish couldn't be shown locally right now (testnet RPC was flaking + local stores stale), but the assembly + node-enforcement are confirmed, and this mirrors the pattern miden-standards uses.

Ships in the next `pm-publisher` wheel (a6), alongside #64 (client reuse + debug off). Pairs with the reconcile-on-conflict safety net already in pragma-sdk (#292).

🤖 Generated with [Claude Code](https://claude.com/claude-code)