### PR TITLE
chore: bump to 0.1.0-alpha.6 (pm-publisher release)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2982,7 +2982,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "pm-accounts"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 dependencies = [
  "anyhow",
  "miden-client",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "pm-oracle-cli"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3030,7 +3030,7 @@ dependencies = [
 
 [[package]]
 name = "pm-publisher-cli"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "pm-types"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 dependencies = [
  "anyhow",
  "miden-client",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "pm-utils-cli"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 unsafe_code = "forbid"
 
 [workspace.package]
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 authors = ["Pragma <https://github.com/astraly-labs>"]
 homepage = "https://www.pragma.build/"
 edition = "2021"

--- a/crates/cli/publisher/pyproject.toml
+++ b/crates/cli/publisher/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pm-publisher"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 description = "Python bindings for Pragma Miden Publisher CLI"
 authors = [{ name = "Pragma", email = "jordy@pragma.build" }]
 requires-python = ">=3.7"


### PR DESCRIPTION
Bumps the workspace + pyproject version `0.1.0-alpha.5` → `0.1.0-alpha.6` to cut the next `pm-publisher` wheel (latest on PyPI is `0.1.0a5`).

The a6 wheel carries:
- #64 — reuse the Miden client across pyo3 calls + `in_debug_mode` off by default (no more `Initializing testnet client` / `failed to load MASM sources` spam).
- #65 — transaction expiration delta set in the publish script (a stalled tx dies deterministically node-side instead of diverging the account).

After merge, tag `py-v0.1.6` → triggers `publish-pypi.yml`. Then bump the pragma-sdk pin to `>=0.1.0a6` + relock + rebuild the price-pusher image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)