### PR TITLE
chore: point addresses at the new Miden 0.15 oracle + publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@
 
 ## Deployments
 
-### Testnet (Miden 0.14)
+### Testnet (Miden 0.15)
 
 | Role       | Account ID                           | Explorer |
 |------------|--------------------------------------|----------|
-| Oracle     | `0xcaf3856aedfa4b106d59998789348f`  | [view](https://testnet.midenscan.com/account/mtst1ar908pt2ahaykyrdtxvc0zf53uujtu0c) |
-| Publisher  | `0xb82114f2a59810006d0410a6c44e46`  | [view](https://testnet.midenscan.com/account/mtst1azuzz98j5kvpqqrdqsg2d3zwgcx394vh) |
+| Oracle     | `0x7ad4aa02b1816c117e32853e210c28`  | [view](https://testnet.midenscan.com/account/0x7ad4aa02b1816c117e32853e210c28) |
+| Publisher  | `0x6d37b2d4aedd697140338bb31c67e3`  | [view](https://testnet.midenscan.com/account/0x6d37b2d4aedd697140338bb31c67e3) |
 
 > Addresses change between testnet iterations. This table is the source of truth.
 

--- a/examples/consume-price/README.md
+++ b/examples/consume-price/README.md
@@ -16,7 +16,7 @@ Expected output:
 Syncing with testnet...
 Latest block: 651945
 Registered publishers: 1
-Imported publisher: 0xb82114f2a59810006d0410a6c44e46
+Imported publisher: 0x6d37b2d4aedd697140338bb31c67e3
 BTC/USD: $76316.00  (raw: 76316000000, 6 decimals)
 ```
 

--- a/examples/consume-price/src/main.rs
+++ b/examples/consume-price/src/main.rs
@@ -11,7 +11,7 @@ use pm_utils_cli::setup_testnet_client;
 use std::collections::BTreeMap;
 
 // ── Pragma Miden testnet oracle ───────────────────────────────────────────────
-const ORACLE_ID: &str = "0xcaf3856aedfa4b106d59998789348f";
+const ORACLE_ID: &str = "0x7ad4aa02b1816c117e32853e210c28";
 
 // ── Asset: BTC/USD (faucet_id "1:0") ─────────────────────────────────────────
 const PAIR_PREFIX: u64 = 1;

--- a/pragma_miden.json
+++ b/pragma_miden.json
@@ -8,12 +8,9 @@
       ]
     },
     "testnet": {
-      "oracle_account_id": "0xcaf3856aedfa4b106d59998789348f",
+      "oracle_account_id": "0x7ad4aa02b1816c117e32853e210c28",
       "publisher_account_ids": [
-        "0xaa9c9ad8583c3b0064eff7356152bd",
-        "0x39c45ece7de124002191469753074f",
-        "0x022c8db22d56b1000643d54faf7487",
-        "0xb82114f2a59810006d0410a6c44e46"
+        "0x6d37b2d4aedd697140338bb31c67e3"
       ]
     }
   }


### PR DESCRIPTION
Repoints config + docs + the consume-price example at the new **Miden 0.15** testnet accounts (the 0.14 `0xcaf3856`/`0xb82114` are dead — 0.15 changed account-id derivation):

- oracle `0x7ad4aa02b1816c117e32853e210c28`
- publisher `0x6d37b2d4aedd697140338bb31c67e3` (ECDSA, registered Active)

Both deployed + verified on testnet (publish-batch + median-batch return correct values).

Files: `pragma_miden.json` (testnet, single new publisher), `README.md` (addresses + "Miden 0.14"→"0.15"), `examples/consume-price/{src/main.rs,README.md}`.

> Note: the GCP-secret `pragma_miden.json` (price-pusher / oracle-service) is the prod source of truth; this repo file feeds local dev + the oracle-service image default. README explorer links use the hex id (regenerate `mtst1…` bech32 if midenscan needs it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)