### PR TITLE
chore(frontend): show the new 0.15 oracle + publisher on the explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@
 
 | Role       | Account ID                           | Explorer |
 |------------|--------------------------------------|----------|
-| Oracle     | `0x7ad4aa02b1816c117e32853e210c28`  | [view](https://testnet.midenscan.com/account/0x7ad4aa02b1816c117e32853e210c28) |
-| Publisher  | `0x6d37b2d4aedd697140338bb31c67e3`  | [view](https://testnet.midenscan.com/account/0x6d37b2d4aedd697140338bb31c67e3) |
+| Oracle     | `0x7ad4aa02b1816c117e32853e210c28`  | [view](https://testnet.midenscan.com/account/mtst1apadf2szkxqkcyt7x2znuggv9qkhccam) |
+| Publisher  | `0x6d37b2d4aedd697140338bb31c67e3`  | [view](https://testnet.midenscan.com/account/mtst1apkn0vk54mwkju2qxw9mx8r8uvhn240g) |
 
 > Addresses change between testnet iterations. This table is the source of truth.
 

--- a/oracle-explorer/app/page.tsx
+++ b/oracle-explorer/app/page.tsx
@@ -19,8 +19,8 @@ const FAUCET_IDS = [
 ];
 
 const CONTRACTS = [
-  { name: "Oracle", address: "mtst1ar908pt2ahaykyrdtxvc0zf53uujtu0c", url: "https://testnet.midenscan.com/account/mtst1ar908pt2ahaykyrdtxvc0zf53uujtu0c" },
-  { name: "Publisher", address: "mtst1azuzz98j5kvpqqrdqsg2d3zwgcx394vh", url: "https://testnet.midenscan.com/account/mtst1azuzz98j5kvpqqrdqsg2d3zwgcx394vh" },
+  { name: "Oracle", address: "mtst1apadf2szkxqkcyt7x2znuggv9qkhccam", url: "https://testnet.midenscan.com/account/mtst1apadf2szkxqkcyt7x2znuggv9qkhccam" },
+  { name: "Publisher", address: "mtst1apkn0vk54mwkju2qxw9mx8r8uvhn240g", url: "https://testnet.midenscan.com/account/mtst1apkn0vk54mwkju2qxw9mx8r8uvhn240g" },
 ];
 
 const PUBLISHER_STEPS = [


### PR DESCRIPTION
Updates the oracle-explorer Deployments panel (`oracle-explorer/app/page.tsx`) and the README explorer links to the new **Miden 0.15** testnet accounts:

- Oracle `0x7ad4aa02b1816c117e32853e210c28` → [mtst1apadf2szkxqkcyt7x2znuggv9qkhccam](https://testnet.midenscan.com/account/mtst1apadf2szkxqkcyt7x2znuggv9qkhccam)
- Publisher `0x6d37b2d4aedd697140338bb31c67e3` → [mtst1apkn0vk54mwkju2qxw9mx8r8uvhn240g](https://testnet.midenscan.com/account/mtst1apkn0vk54mwkju2qxw9mx8r8uvhn240g)

Display/links only — the explorer's price queries read the oracle id from the mounted `pragma_miden.json` (`miden-oracle-config-pragma`, already repointed in the rollout), so the data path is unchanged.

> Heads-up: this lives in `oracle-explorer/**`, so merging to `main` triggers `docker-build.yml` → a new `miden-oracle` image (tagged with the merge sha). Because `update-devops` is broken (expired `DEVOPS_GITHUB_TOKEN`), the devops `values-mainnet.yaml` `tag:` must be bumped by hand to that new sha for the new panel to go live on miden.pragma.build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)