### PR TITLE
fix(helm): derive keystore volume name from secretName (0.15 invalid k8s names)

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -48,7 +48,11 @@ spec:
             - name: workspace-data
               mountPath: /data/oracle-workspace
             {{- range .Values.keystoreSecrets }}
-            - name: keystore-{{ .fileName }}
+            # Volume name is derived from secretName (short, RFC-1123 valid),
+            # NOT fileName: Miden 0.15 keystore filenames are 0x-hex (>63 chars)
+            # or key_index.json (has '_'/'.') which are invalid k8s names. The
+            # on-disk filename still uses fileName via mountPath.
+            - name: keystore-{{ .secretName }}
               mountPath: /secrets/keystore/{{ .fileName }}
               subPath: keystore
               readOnly: true
@@ -118,7 +122,7 @@ spec:
         - name: workspace-data
           emptyDir: {}
         {{- range .Values.keystoreSecrets }}
-        - name: keystore-{{ .fileName }}
+        - name: keystore-{{ .secretName }}
           secret:
             secretName: {{ .secretName }}
         {{- end }}


### PR DESCRIPTION
## Symptom
ArgoCD sync of `mainnet-miden-oracle-service` fails:
```
Deployment ... is invalid:
- volumes[1].name: "keystore-0xaaab777a...724b46": must be no more than 63 characters
- volumes[2].name: "keystore-key_index.json": ... RFC 1123 label ... '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
- initContainers[0].volumeMounts[1].name: Not found: "keystore-0xaaab777a..."
- initContainers[0].volumeMounts[2].name: Not found: "keystore-key_index.json"
```

## Cause
The chart named the k8s volume/volumeMount `keystore-{{ .fileName }}`. Under Miden 0.14 `fileName` was a short decimal SipHash → fine. Under **0.15** the keystore filenames are `0x`-hex (`keystore-0x…` = 75 chars > 63) or `key_index.json` (`_`/`.` invalid in a volume name), so the rendered Deployment is invalid.

## Fix
Derive the k8s volume name from **`.secretName`** (short, RFC-1123 valid, unique per entry); keep `.fileName` only for the on-disk `mountPath` (the entrypoint still copies `/secrets/keystore/<fileName>`). Verified with `helm template`:
- `keystore-miden-oracle-keystore-pragma` (37), `keystore-miden-oracle-key-index` (31) — both ≤63, valid
- mountPaths still `/secrets/keystore/0xaaab777a…` and `/secrets/keystore/key_index.json`

The oracle-service Argo app pulls this chart from pragma-miden `main`, so this needs to land on main for the sync to recover. (The price-pusher uses a different chart in pragma-sdk and was unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)