### PR TITLE
fix(publisher): surface the real gRPC error on sync failures

### DIFF
--- a/crates/cli/publisher/src/commands/init.rs
+++ b/crates/cli/publisher/src/commands/init.rs
@@ -49,7 +49,9 @@ impl InitCmd {
         client
             .sync_state()
             .await
-            .map_err(|e| anyhow::anyhow!("Could not sync state during init: {}", e))?;
+            // See sync.rs: {:?} keeps the gRPC status detail that ClientError's
+            // Display (#[error("RPC error")]) would otherwise drop.
+            .map_err(|e| anyhow::anyhow!("Could not sync state during init: {e:?}"))?;
 
         let (publisher_account, _) = PublisherAccountBuilder::new()
             .with_client(client)

--- a/crates/cli/publisher/src/commands/sync.rs
+++ b/crates/cli/publisher/src/commands/sync.rs
@@ -11,7 +11,11 @@ impl SyncCmd {
         let new_details = client
             .sync_state()
             .await
-            .map_err(|e| anyhow::anyhow!("Could not sync state: {}", e))?;
+            // Debug-format the client error: miden_client's ClientError uses
+            // #[error("RPC error")], so its Display drops the underlying gRPC
+            // status. {:?} surfaces the real cause (e.g. the SyncTransactions
+            // "decoded message length too large" OutOfRange) in the logs.
+            .map_err(|e| anyhow::anyhow!("Could not sync state: {e:?}"))?;
         println!("🔁 Sync successful!\n");
 
         println!("State synced to block {}", new_details.block_num);


### PR DESCRIPTION
## Why
During the current Miden testnet outage, prod logs only showed the opaque `Failed to publish batch ...: Sync failed: Could not sync state: RPC error`. The real cause was hidden: `miden_client::ClientError` uses `#[error("RPC error")]`, so its **Display** drops the underlying gRPC status, and the sync command formatted it with `{}` (Display). The actual error is only visible via `{:?}` (Debug):
```
RpcError(... endpoint: SyncTransactions, OutOfRange,
  "decoded message length too large: found 6146702 bytes, the limit is: 4194304 bytes" ...)
```
i.e. the node's `SyncTransactions` response (~6.1 MB) exceeds miden-client's default 4 MiB gRPC decode limit. (I originally had to run `pm-oracle-cli publishers`, which `.unwrap()`s the same `sync_state()` and thus prints Debug, to see this.)

## Change
Debug-format (`{:?}`) the client error on the two sync paths — `commands/sync.rs` and `commands/init.rs` — so the gRPC status detail reaches the logs, and (through the pyo3 binding → pragma-sdk) the price-pusher logs. `publish_batch.rs` already used `{:?}`, which is why tx-submit errors (e.g. "transaction expired") were already legible.

## Verified
Rebuilt `pm-publisher-cli` and re-ran `sync` against testnet — it now prints the full `OutOfRange ... decoded message length too large` detail instead of `RPC error`.

## Note
This is an observability change only — it does **not** fix the sync outage (that needs a miden-client patch raising `max_decoding_message_size`, escalated to Miden). It requires a new `pm-publisher` wheel (a8) + rebuild to take effect in prod, so the confirmation lands next time the wheel is bumped. The laptop repro against the same testnet endpoint already confirms it's the same root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)