### PR TITLE
fix(publisher): self-heal wedged Miden client on poisoned store pool (a9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3428,7 +3428,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pm-accounts"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "anyhow",
  "miden-client",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "pm-oracle-cli"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "pm-publisher-cli"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3503,7 +3503,7 @@ dependencies = [
 
 [[package]]
 name = "pm-types"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "anyhow",
  "miden-client",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "pm-utils-cli"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 unsafe_code = "forbid"
 
 [workspace.package]
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 authors = ["Pragma <https://github.com/astraly-labs>"]
 homepage = "https://www.pragma.build/"
 edition = "2021"

--- a/crates/cli/publisher/pyproject.toml
+++ b/crates/cli/publisher/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pm-publisher"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 description = "Python bindings for Pragma Miden Publisher CLI"
 authors = [{ name = "Pragma", email = "jordy@pragma.build" }]
 requires-python = ">=3.7"

--- a/crates/cli/publisher/src/lib.rs
+++ b/crates/cli/publisher/src/lib.rs
@@ -3,7 +3,7 @@ use miden_client::{keystore::FilesystemKeyStore, Client};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use tokio::runtime::{Builder, Runtime};
 use tokio::sync::Mutex as AsyncMutex;
@@ -47,11 +47,7 @@ async fn cached_client(
     store_config: PathBuf,
     keystore_path: Option<String>,
 ) -> PyResult<CachedClient> {
-    let key = format!(
-        "{network}|{}|{}",
-        store_config.to_string_lossy(),
-        keystore_path.as_deref().unwrap_or("")
-    );
+    let key = client_key(network, &store_config, keystore_path.as_deref());
     let cache = CLIENTS.get_or_init(|| StdMutex::new(HashMap::new()));
     if let Some(client) = cache.lock().unwrap().get(&key) {
         return Ok(client.clone());
@@ -62,6 +58,58 @@ async fn cached_client(
         setup_client(network, store_config, keystore_path).await?,
     ));
     Ok(cache.lock().unwrap().entry(key).or_insert(client).clone())
+}
+
+/// Cache key for a client — one unique (network, store path, keystore path)
+/// combination. Kept in a single place so `cached_client` and the eviction
+/// path can never drift on how the key is formed.
+fn client_key(network: &str, store_config: &Path, keystore_path: Option<&str>) -> String {
+    format!(
+        "{network}|{}|{}",
+        store_config.to_string_lossy(),
+        keystore_path.unwrap_or("")
+    )
+}
+
+/// Drop the cached client for `key` so the next pyo3 call rebuilds a fresh one.
+fn evict_client(key: &str) {
+    if let Some(cache) = CLIENTS.get() {
+        cache.lock().unwrap().remove(key);
+    }
+}
+
+/// Detect the "wedged store" failure. The Miden client's SQLite pool (deadpool)
+/// poisons its connection `Mutex` the first time a store operation panics.
+/// Because we cache the client for the whole process lifetime, EVERY later call
+/// then fails forever with the same poisoned-pool error — a silent, permanent
+/// Miden outage (the embedding price-pusher only logs + retries each tick, and
+/// its liveness stays green off the Starknet feed). We match on the error's
+/// Debug form (the underlying `StoreError` is surfaced via `{e:?}`, e.g. in
+/// sync.rs) so the caller can evict + rebuild instead of staying wedged.
+fn store_is_wedged<E: std::fmt::Debug>(err: &E) -> bool {
+    let s = format!("{err:?}");
+    s.contains("PoisonError")
+        || s.contains(r#"DatabaseError("Panic")"#)
+        || (s.contains("StoreError") && s.contains("Panic"))
+}
+
+/// Map a command result to a `PyResult`, evicting the cached client first when
+/// the failure is a wedged (poisoned) store pool. This turns a permanent,
+/// process-lifetime Miden outage into a self-healing blip: the very next call
+/// rebuilds a fresh client (new SQLite pool + `Mutex`) over the same store file.
+fn map_cmd_err<T, E>(res: Result<T, E>, key: &str, label: &str) -> PyResult<T>
+where
+    E: std::fmt::Display + std::fmt::Debug,
+{
+    res.map_err(|e| {
+        if store_is_wedged(&e) {
+            evict_client(key);
+            eprintln!(
+                "pm-publisher: Miden store pool wedged during {label}; evicted the cached client, it will be rebuilt on the next call"
+            );
+        }
+        PyValueError::new_err(format!("{label} failed: {e}"))
+    })
 }
 
 /// Initialize publisher and return a client handle
@@ -79,6 +127,7 @@ fn py_init(
 
         // Use appropriate client setup based on network parameter
         let network_str = network.as_deref().unwrap_or("testnet");
+        let key = client_key(network_str, &store_config, keystore_path.as_deref());
         let client_arc = cached_client(network_str, store_config, keystore_path).await?;
         let mut client = client_arc.lock().await;
 
@@ -86,9 +135,7 @@ fn py_init(
             oracle_id: Some(oracle_id),
         };
 
-        cmd.call(&mut client, network_str)
-            .await
-            .map_err(|e| PyValueError::new_err(format!("Init failed: {}", e)))?;
+        map_cmd_err(cmd.call(&mut client, network_str).await, &key, "Init")?;
 
         Ok(())
     })
@@ -112,6 +159,7 @@ fn py_publish(
 
         let network_str = network.as_deref().unwrap_or("testnet");
 
+        let key = client_key(network_str, &store_config, keystore_path.as_deref());
         let client_arc = cached_client(network_str, store_config, keystore_path).await?;
         let mut client = client_arc.lock().await;
 
@@ -123,9 +171,7 @@ fn py_publish(
             publisher_id: None,
         };
 
-        cmd.call(&mut client, network_str)
-            .await
-            .map_err(|e| PyValueError::new_err(format!("Publish failed: {}", e)))?;
+        map_cmd_err(cmd.call(&mut client, network_str).await, &key, "Publish")?;
 
         Ok(())
     })
@@ -146,14 +192,12 @@ fn py_get_entry(
 
         let network_str = network.as_deref().unwrap_or("testnet");
 
+        let key = client_key(network_str, &store_config, keystore_path.as_deref());
         let client_arc = cached_client(network_str, store_config, keystore_path).await?;
         let mut client = client_arc.lock().await;
 
         let cmd = GetEntryCmd { faucet_id };
-        let entry = cmd
-            .call(&mut client, network_str)
-            .await
-            .map_err(|e| PyValueError::new_err(format!("Get entry failed: {}", e)))?;
+        let entry = map_cmd_err(cmd.call(&mut client, network_str).await, &key, "Get entry")?;
 
         Ok(serde_json::json!({
             "faucet_id": entry.faucet_id,
@@ -179,13 +223,12 @@ fn py_entry(
 
         let network_str = network.as_deref().unwrap_or("testnet");
 
+        let key = client_key(network_str, &store_config, keystore_path.as_deref());
         let client_arc = cached_client(network_str, store_config, keystore_path).await?;
         let mut client = client_arc.lock().await;
 
         let cmd = EntryCmd { faucet_id };
-        cmd.call(&mut client, network_str)
-            .await
-            .map_err(|e| PyValueError::new_err(format!("Entry failed: {}", e)))?;
+        map_cmd_err(cmd.call(&mut client, network_str).await, &key, "Entry")?;
 
         Ok("Entry details retrieved successfully!".to_string())
     })
@@ -209,12 +252,15 @@ fn py_publish_batch(
     rt().block_on(async {
         let store_config = get_store_config(storage_path);
         let network_str = network.as_deref().unwrap_or("testnet");
+        let key = client_key(network_str, &store_config, keystore_path.as_deref());
         let client_arc = cached_client(network_str, store_config, keystore_path).await?;
         let mut client = client_arc.lock().await;
 
-        do_publish_batch(&mut client, network_str, &entries, None)
-            .await
-            .map_err(|e| PyValueError::new_err(format!("Publish batch failed: {}", e)))?;
+        map_cmd_err(
+            do_publish_batch(&mut client, network_str, &entries, None).await,
+            &key,
+            "Publish batch",
+        )?;
 
         Ok(())
     })
@@ -236,6 +282,7 @@ fn py_import_account(
     rt().block_on(async {
         let store_config = get_store_config(storage_path);
         let network_str = network.as_deref().unwrap_or("testnet");
+        let key = client_key(network_str, &store_config, keystore_path.as_deref());
         let client_arc = cached_client(network_str, store_config, keystore_path).await?;
         let mut client = client_arc.lock().await;
 
@@ -243,10 +290,11 @@ fn py_import_account(
             PyValueError::new_err(format!("Invalid account_id '{}': {}", account_id, e))
         })?;
 
-        client
-            .import_account_by_id(id)
-            .await
-            .map_err(|e| PyValueError::new_err(format!("Import account failed: {}", e)))?;
+        map_cmd_err(
+            client.import_account_by_id(id).await,
+            &key,
+            "Import account",
+        )?;
 
         Ok(())
     })
@@ -266,13 +314,12 @@ fn py_sync(
         let network_str = network.as_deref().unwrap_or("testnet");
 
         // Use appropriate client setup based on network parameter
+        let key = client_key(network_str, &store_config, keystore_path.as_deref());
         let client_arc = cached_client(network_str, store_config, keystore_path).await?;
         let mut client = client_arc.lock().await;
 
         let cmd = SyncCmd {};
-        cmd.call(&mut client)
-            .await
-            .map_err(|e| PyValueError::new_err(format!("Sync failed: {}", e)))?;
+        map_cmd_err(cmd.call(&mut client).await, &key, "Sync")?;
 
         Ok("Sync successful!".to_string())
     })
@@ -333,4 +380,31 @@ fn get_store_config(storage_path: Option<String>) -> PathBuf {
         None => PathBuf::new(),
     };
     exec_dir.join(STORE_FILENAME)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::store_is_wedged;
+
+    #[test]
+    fn detects_poisoned_pool_error() {
+        // The exact shape surfaced in prod logs (sync.rs Debug-formats the error).
+        let e = anyhow::anyhow!(r#"Could not sync state: StoreError(DatabaseError("Panic"))"#);
+        assert!(store_is_wedged(&e));
+    }
+
+    #[test]
+    fn detects_raw_deadpool_poison() {
+        let e = anyhow::anyhow!("{}", "unwrap() on an `Err` value: PoisonError { .. }");
+        assert!(store_is_wedged(&e));
+    }
+
+    #[test]
+    fn ignores_ordinary_errors() {
+        // A flaky RPC or an expired tx must NOT evict the cached client.
+        let rpc = anyhow::anyhow!("Could not sync state: RPC error");
+        let expired = anyhow::anyhow!("transaction expired at block height 16");
+        assert!(!store_is_wedged(&rpc));
+        assert!(!store_is_wedged(&expired));
+    }
 }


### PR DESCRIPTION
## Incident (2026-08-09)

Miden feed **silently down in prod** — `mainnet-price-pusher-service-pragma-sdk` published `0/5` for hours, **0 restarts in 3d14h**, pod stayed `1/1`. Logs: `StoreError(DatabaseError("Panic"))` on every sync/publish + `thread 'pm-publisher' panicked at deadpool-sync-0.1.4/src/lib.rs:123: PoisonError` (3224× — all the cascade; the true first panic had rotated out of the node's ~80-min log window).

## Root cause

The pyo3 bindings cache **one Miden client — and its deadpool SQLite pool — for the whole process lifetime** (`CLIENTS` map in `lib.rs`). The **first** store panic poisons the deadpool connection `Mutex` (in-memory). Because the client is cached, **every** later `sync`/`publish_batch`/`get_entry` re-hits the poisoned `Mutex` → the same error forever → permanent zombie. The embedding price-pusher catches it, returns `[False]`, and retries each tick; its liveness stays green off the Starknet feed → the outage is **silent** to k8s.

## Fix

- `store_is_wedged` detects the wedged-store error (`PoisonError` / `DatabaseError("Panic")` / `StoreError`+`Panic`).
- `map_cmd_err` wraps all **7 pyfunctions**: on a wedged error it **evicts the cached client** before returning, so the next call rebuilds a fresh client (new pool + `Mutex`) over the same store file.
- **Self-heals within one tick**: `sync()` fails + evicts → `publish_batch()` (same tick) rebuilds + publishes. No pod restart needed.
- `client_key` factored out so `cached_client` and the eviction path can't drift on the key.

Handles the in-memory-poison case (what prod hit). A genuinely corrupt on-disk DB would rebuild-loop instead — follow-up backstop is k8s-side: make the price-pusher liveness reflect a persistently-wedged Miden so it restarts (fresh emptyDir) **and** de-silences the failure.

## Recovery already applied

`kubectl rollout restart deployment/mainnet-price-pusher-service-pragma-sdk -n mainnet` → emptyDir store wiped + fresh process → cold-sync (~192s) → `MIDEN: published 5/5` confirmed. Feed is live; this PR prevents recurrence.

## Tests / checks

- +3 unit tests for `store_is_wedged` (detects poison shapes, ignores flaky-RPC / expired-tx).
- `cargo test` / `clippy -D warnings` / `fmt --check`: all green.
- Bumps workspace + `pm-publisher` to `0.1.0-alpha.9`.

## Rollout after merge (same chain as a8)

tag `py-v0.1.9` → PyPI a9 → pragma-sdk pin `>=0.1.0a9` + relock → rebuild price-pusher image + rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)