### PR TITLE
fix(examples): consume-price prints BTC/USD with its 8 decimals, not 6

### DIFF
--- a/examples/consume-price/README.md
+++ b/examples/consume-price/README.md
@@ -17,7 +17,7 @@ Syncing with testnet...
 Latest block: 651945
 Registered publishers: 1
 Imported publisher: 0x6d37b2d4aedd697140338bb31c67e3
-BTC/USD: $76316.00  (raw: 76316000000, 6 decimals)
+BTC/USD: $78457.20  (raw: 7845720000000, 8 decimals)
 ```
 
 ## How it works
@@ -34,19 +34,21 @@ Local state is stored in `./miden_storage/store.sqlite3` (created automatically)
 
 Edit `PAIR_PREFIX` / `PAIR_SUFFIX` in `src/main.rs`:
 
-| faucet_id | PREFIX | SUFFIX | Asset    |
-|-----------|--------|--------|----------|
-| `1:0`     | `1`    | `0`    | BTC/USD  |
-| `2:0`     | `2`    | `0`    | ETH/USD  |
-| `3:0`     | `3`    | `0`    | WBTC/USD |
-| `4:0`     | `4`    | `0`    | USDT/USD |
-| `5:0`     | `5`    | `0`    | DAI/USD  |
-| `6:0`     | `6`    | `0`    | ZEC/USD  |
-| `7:0`     | `7`    | `0`    | XMR/USD  |
-| `8:0`     | `8`    | `0`    | DASH/USD |
-| `9:0`     | `9`    | `0`    | XAUT/USD |
-| `10:0`    | `10`   | `0`    | PAXG/USD |
-| `11:0`    | `11`   | `0`    | LINK/USD |
-| `12:0`    | `12`   | `0`    | UNI/USD  |
-| `13:0`    | `13`   | `0`    | AAVE/USD |
-| `14:0`    | `14`   | `0`    | MORPHO/USD |
+| faucet_id | PREFIX | SUFFIX | Asset      | decimals |
+|-----------|--------|--------|------------|----------|
+| `1:0`     | `1`    | `0`    | BTC/USD    | 8        |
+| `2:0`     | `2`    | `0`    | ETH/USD    | 8        |
+| `3:0`     | `3`    | `0`    | WBTC/USD   | 8        |
+| `4:0`     | `4`    | `0`    | USDT/USD   | 6        |
+| `5:0`     | `5`    | `0`    | DAI/USD    | 8        |
+| `6:0`     | `6`    | `0`    | ZEC/USD    | 8        |
+| `7:0`     | `7`    | `0`    | XMR/USD    | 8        |
+| `8:0`     | `8`    | `0`    | DASH/USD   | 8        |
+| `9:0`     | `9`    | `0`    | XAUT/USD   | 6        |
+| `10:0`    | `10`   | `0`    | PAXG/USD   | 8        |
+| `11:0`    | `11`   | `0`    | LINK/USD   | 8        |
+| `12:0`    | `12`   | `0`    | UNI/USD    | 8        |
+| `13:0`    | `13`   | `0`    | AAVE/USD   | 8        |
+| `14:0`    | `14`   | `0`    | MORPHO/USD | 8        |
+
+`get_median` returns the raw integer only: scale it by the pair's decimals (`min(base.decimals, quote.decimals)` in pragma-sdk, 8 for most pairs, 6 for USDT/USD and XAUT/USD).

--- a/examples/consume-price/src/main.rs
+++ b/examples/consume-price/src/main.rs
@@ -131,9 +131,11 @@ async fn main() -> Result<()> {
     if is_tracked == 0 {
         println!("BTC/USD: not tracked by the oracle.");
     } else {
+        // get_median returns the raw integer; decimals are a property of the
+        // pair (8 for BTC/USD, see README), not returned on the stack.
         println!(
-            "BTC/USD: ${:.2}  (raw: {}, 6 decimals)",
-            median as f64 / 1_000_000.0,
+            "BTC/USD: ${:.2}  (raw: {}, 8 decimals)",
+            median as f64 / 100_000_000.0,
             median
         );
     }


### PR DESCRIPTION
The pusher publishes each pair with `min(base.decimals, quote.decimals)`: 8 for BTC/USD, 6 for USDT/USD and XAUT/USD. The example still divided the raw median by 1e6 and its README promised "6 decimals", so it printed \$7,845,720 for a \$78,457 BTC.

- `main.rs`: divide by 1e8 for BTC/USD, comment that decimals are a property of the pair and not returned on the stack.
- README: expected output fixed, faucet table carries the per-pair decimals for the 14 pairs.

`cargo check -p consume-price` and `cargo fmt --check` clean. Same content mirrored in the docs (astraly-labs/docs#6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfERCvK8YrPYGBcJWhyF3H