### PR TITLE
fix(examples): decode publisher ids like pm-oracle-cli ([prefix, suffix, 0, 0])

### DIFF
--- a/examples/consume-price/README.md
+++ b/examples/consume-price/README.md
@@ -17,7 +17,7 @@ Syncing with testnet...
 Latest block: 651945
 Registered publishers: 1
 Imported publisher: 0x6d37b2d4aedd697140338bb31c67e3
-BTC/USD: $78457.20  (raw: 7845720000000, 8 decimals)
+BTC/USD: $78600.70  (raw: 7860070031031, 8 decimals)
 ```
 
 ## How it works

--- a/examples/consume-price/src/main.rs
+++ b/examples/consume-price/src/main.rs
@@ -60,7 +60,8 @@ async fn main() -> Result<()> {
             let w = storage
                 .get_map_item(&publishers_slot, key)
                 .with_context(|| format!("publisher at index {i} not found"))?;
-            Ok(AccountId::new_unchecked([w[3], w[2]]))
+            // Same layout as pm-oracle-cli: [prefix, suffix, 0, 0]
+            Ok(AccountId::new_unchecked([w[0], w[1]]))
         })
         .collect::<Result<_>>()?;
 


### PR DESCRIPTION
Since the 0.15 migration `examples/consume-price` read the publisher account id from the oracle's storage map as `[w[3], w[2]]` and panicked on the first publisher:

```
prefix should contain a valid account ID version: UnknownAccountIdVersion(0)
```

The CLI commands that work in prod (`median`, `median-batch`, `publishers`) read `[w[0], w[1]]`. Aligned, and verified live against testnet from a clean store:

```
Latest block: 2221319
Registered publishers: 1
Imported publisher: 0x6d37b2d4aedd697140338bb31c67e3
BTC/USD: $78600.70  (raw: 7860070031031, 8 decimals)
```

Follow-up to #76; the docs sample gets the same one-line fix (astraly-labs/docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfERCvK8YrPYGBcJWhyF3H