### PR TITLE
fix(publisher): release the GIL while the bindings block on the Miden RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3428,7 +3428,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pm-accounts"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 dependencies = [
  "anyhow",
  "miden-client",
@@ -3449,7 +3449,7 @@ dependencies = [
 
 [[package]]
 name = "pm-oracle-cli"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "pm-publisher-cli"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3503,7 +3503,7 @@ dependencies = [
 
 [[package]]
 name = "pm-types"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 dependencies = [
  "anyhow",
  "miden-client",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "pm-utils-cli"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 unsafe_code = "forbid"
 
 [workspace.package]
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 authors = ["Pragma <https://github.com/astraly-labs>"]
 homepage = "https://www.pragma.build/"
 edition = "2021"

--- a/crates/cli/publisher/pyproject.toml
+++ b/crates/cli/publisher/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pm-publisher"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 description = "Python bindings for Pragma Miden Publisher CLI"
 authors = [{ name = "Pragma", email = "jordy@pragma.build" }]
 requires-python = ">=3.7"

--- a/crates/cli/publisher/src/lib.rs
+++ b/crates/cli/publisher/src/lib.rs
@@ -3,6 +3,7 @@ use miden_client::{keystore::FilesystemKeyStore, Client};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use std::collections::HashMap;
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use tokio::runtime::{Builder, Runtime};
@@ -32,6 +33,20 @@ fn rt() -> &'static Runtime {
             .build()
             .expect("failed to build pm-publisher Tokio runtime")
     })
+}
+
+/// Run a binding's work on the shared runtime with the GIL released.
+///
+/// Each call blocks the calling thread for a full RPC round-trip, up to the
+/// client's timeout. Holding the GIL for that long freezes the embedding
+/// interpreter: in the price-pusher it stalled the asyncio loop and every
+/// HTTP fetcher timed out while the Miden RPC hung (2026-09-09).
+fn block_on<T, Fut>(py: Python<'_>, task: impl FnOnce() -> Fut + Send) -> T
+where
+    Fut: Future<Output = T>,
+    T: Send,
+{
+    py.allow_threads(|| rt().block_on(task()))
 }
 
 /// Cache of Miden clients keyed by (network, store path, keystore path), so we
@@ -116,12 +131,13 @@ where
 #[pyfunction]
 #[pyo3(name = "init")]
 fn py_init(
+    py: Python<'_>,
     oracle_id: String,
     storage_path: Option<String>,
     keystore_path: Option<String>,
     network: Option<String>,
 ) -> PyResult<()> {
-    rt().block_on(async {
+    block_on(py, || async move {
         // Convert storage_path to PathBuf, default to current dir if None
         let store_config = get_store_config(storage_path);
 
@@ -144,7 +160,9 @@ fn py_init(
 /// Publish price using existing client
 #[pyfunction]
 #[pyo3(name = "publish")]
+#[allow(clippy::too_many_arguments)]
 fn py_publish(
+    py: Python<'_>,
     faucet_id: String,
     price: u64,
     decimals: u32,
@@ -153,7 +171,7 @@ fn py_publish(
     keystore_path: Option<String>,
     network: Option<String>,
 ) -> PyResult<()> {
-    rt().block_on(async {
+    block_on(py, || async move {
         // Create client inside the function like the other functions
         let store_config = get_store_config(storage_path);
 
@@ -182,12 +200,13 @@ fn py_publish(
 #[pyfunction]
 #[pyo3(name = "get_entry")]
 fn py_get_entry(
+    py: Python<'_>,
     faucet_id: String,
     storage_path: Option<String>,
     keystore_path: Option<String>,
     network: Option<String>,
 ) -> PyResult<String> {
-    rt().block_on(async {
+    block_on(py, || async move {
         let store_config = get_store_config(storage_path);
 
         let network_str = network.as_deref().unwrap_or("testnet");
@@ -213,12 +232,13 @@ fn py_get_entry(
 #[pyfunction]
 #[pyo3(name = "entry")]
 fn py_entry(
+    py: Python<'_>,
     faucet_id: String,
     storage_path: Option<String>,
     keystore_path: Option<String>,
     network: Option<String>,
 ) -> PyResult<String> {
-    rt().block_on(async {
+    block_on(py, || async move {
         let store_config = get_store_config(storage_path);
 
         let network_str = network.as_deref().unwrap_or("testnet");
@@ -241,6 +261,7 @@ fn py_entry(
 #[pyfunction]
 #[pyo3(name = "publish_batch")]
 fn py_publish_batch(
+    py: Python<'_>,
     entries: Vec<(String, u64, u32, u64)>,
     storage_path: Option<String>,
     keystore_path: Option<String>,
@@ -249,7 +270,7 @@ fn py_publish_batch(
     if entries.is_empty() {
         return Ok(());
     }
-    rt().block_on(async {
+    block_on(py, || async move {
         let store_config = get_store_config(storage_path);
         let network_str = network.as_deref().unwrap_or("testnet");
         let key = client_key(network_str, &store_config, keystore_path.as_deref());
@@ -274,12 +295,13 @@ fn py_publish_batch(
 #[pyfunction]
 #[pyo3(name = "import_account")]
 fn py_import_account(
+    py: Python<'_>,
     account_id: String,
     storage_path: Option<String>,
     keystore_path: Option<String>,
     network: Option<String>,
 ) -> PyResult<()> {
-    rt().block_on(async {
+    block_on(py, || async move {
         let store_config = get_store_config(storage_path);
         let network_str = network.as_deref().unwrap_or("testnet");
         let key = client_key(network_str, &store_config, keystore_path.as_deref());
@@ -304,11 +326,12 @@ fn py_import_account(
 #[pyfunction]
 #[pyo3(name = "sync")]
 fn py_sync(
+    py: Python<'_>,
     storage_path: Option<String>,
     keystore_path: Option<String>,
     network: Option<String>,
 ) -> PyResult<String> {
-    rt().block_on(async {
+    block_on(py, || async move {
         let store_config = get_store_config(storage_path);
 
         let network_str = network.as_deref().unwrap_or("testnet");


### PR DESCRIPTION
## Problem

Every `pm_publisher` binding ran `rt().block_on(...)` while holding the GIL. A call therefore blocked the whole embedding interpreter for as long as the RPC took, up to the client timeout.

In the pragma-sdk price-pusher the bindings run through `asyncio.to_thread`, so this froze the asyncio loop while the Miden testnet RPC hung on 2026-09-09 05:43-06:00 UTC: every HTTP fetcher hit its 10s timeout (351 timeouts in 17 min) and the Starknet feed thinned out because of a Miden outage. Fast Miden failures (`Unavailable`) do not trigger it, slow ones (`Timeout expired`) do.

## Fix

- `block_on(py, task)` helper: `py.allow_threads(|| rt().block_on(task()))`. The 7 bindings take `py: Python<'_>` and go through it. The calling thread still blocks, but without the GIL, so other Python threads keep running.
- `pm-publisher` bumped to `0.1.0-alpha.10` (pyproject + workspace).

## Verification

- `cargo check`, `cargo clippy --all-targets -D warnings`, `cargo fmt --check` pass on the crate.
- Baseline reproduced with the published `0.1.0a9` wheel: a local TCP black hole on the `local` endpoint (accepts, never answers) and `pm_publisher.sync` in a worker thread. The main Python thread never got the GIL back: killed after 20 s without a single tick.
- The patched wheel could not be built locally (disk full during the release build); the same probe will be run on the `py-v0.1.10` wheel published by CI before pragma-sdk picks it up.

## Follow-up

- pragma-sdk: pin `pm-publisher>=0.1.0a10`, relock, release, bump devops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fhx2WEDuWHDrpo8ZLtZRbo
