### PR TITLE
feat: migrate workspace to Miden 0.16 (testnet node 0.16 rejects 0.15 clients)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -22,12 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Toolchain pinned in rust-toolchain.toml (miden 0.16 needs rustc >= 1.98).
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly-2025-03-11
           target: ${{ matrix.target }}
-          override: true
 
       - name: Build wheel (Linux)
         if: matrix.runner == 'ubuntu-latest'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +61,16 @@ dependencies = [
  "ruint",
  "rustc-hash",
  "sha3 0.11.0",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
+dependencies = [
+ "arrayvec",
+ "bytes",
 ]
 
 [[package]]
@@ -177,6 +197,195 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint 0.4.6",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint 0.4.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,15 +396,6 @@ name = "arrayvec"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
-
-[[package]]
-name = "ascii-canvas"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
-dependencies = [
- "term 1.2.1",
-]
 
 [[package]]
 name = "async-trait"
@@ -213,6 +413,17 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "autocfg"
@@ -251,6 +462,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,30 +492,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +502,18 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "blake3"
@@ -383,6 +588,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,8 +630,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cipher 0.5.2",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -429,11 +652,23 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead",
- "chacha20",
- "cipher",
- "poly1305",
+ "aead 0.5.2",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
+ "poly1305 0.8.0",
  "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
+dependencies = [
+ "aead 0.6.1",
+ "chacha20 0.10.2",
+ "cipher 0.5.2",
+ "poly1305 0.9.1",
 ]
 
 [[package]]
@@ -456,8 +691,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -499,6 +745,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "codegen"
@@ -544,6 +796,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +866,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -656,6 +941,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -697,6 +998,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,7 +1017,23 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
+ "rustc_version 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
  "rustc_version 0.4.1",
  "subtle",
  "zeroize",
@@ -825,8 +1152,29 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a878c850e9e421b20262e9b41f9c860e4785fa07541c266b62ff9d1ef998a80a"
+dependencies = [
+ "const-oid 0.10.2",
+ "zeroize",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -854,12 +1202,21 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -871,7 +1228,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -913,12 +1272,27 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.2",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -927,8 +1301,18 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "pkcs8 0.11.0",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -937,12 +1321,39 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "serde",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -957,27 +1368,39 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array",
- "group",
- "hkdf",
- "pkcs8",
+ "group 0.13.0",
+ "hkdf 0.12.4",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "ena"
-version = "0.14.4"
+name = "elliptic-curve"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
- "log",
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hkdf 0.13.0",
+ "hybrid-array",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -985,6 +1408,26 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
 
 [[package]]
 name = "env_filter"
@@ -1033,7 +1476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1055,6 +1498,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,10 +1530,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1082,6 +1563,9 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
+ "byteorder",
+ "rand 0.8.6",
+ "rustc-hex",
  "static_assertions",
 ]
 
@@ -1104,6 +1588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,6 +1609,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "fs-err"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,6 +1622,12 @@ checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1275,6 +1780,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -1308,8 +1814,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1338,7 +1855,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1346,6 +1863,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1386,7 +1906,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1396,6 +1925,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1445,11 +1983,13 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "27f864f10dfb56725ce5ce5472bc52252c8f93a4ab86327122cebf62c5f59a17"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -1538,6 +2078,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1572,6 +2132,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,7 +2148,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1596,9 +2165,36 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -1662,11 +2258,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "once_cell",
- "sha2",
- "signature",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "k256"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
+dependencies = [
+ "cpubits",
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primeorder",
+ "sha2 0.11.0",
+ "wnaf",
 ]
 
 [[package]]
@@ -1689,34 +2299,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "lalrpop"
-version = "0.22.2"
+name = "konst"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
 dependencies = [
- "ascii-canvas",
- "bit-set",
- "ena",
- "itertools",
- "lalrpop-util",
- "petgraph 0.7.1",
- "regex",
- "regex-syntax",
- "sha3 0.10.9",
- "string_cache",
- "term 1.2.1",
- "unicode-xid",
- "walkdir",
+ "konst_macro_rules",
 ]
 
 [[package]]
-name = "lalrpop-util"
-version = "0.22.2"
+name = "konst_macro_rules"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
-dependencies = [
- "rustversion",
-]
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -1893,35 +2488,37 @@ dependencies = [
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd45076fe4fef71f0f8b30aa0f018eb39c3086eeb5f3cafc0e12d60cd28339e"
+checksum = "00ff2a44c7f7dc497ac56c74dca5b3465b4b46be066fa88c2c58a8eb1bcb2dc8"
 dependencies = [
- "miden-core 0.23.4",
- "miden-crypto 0.25.1",
+ "miden-constraint-compiler",
+ "miden-core 0.29.4",
+ "miden-crypto 0.29.4",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "miden-agglayer"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ead17cc16651de0fea5fc3ea67109ad449c7bb274ca8ff91c5b25e2be4a0c9f8"
+checksum = "c9340d981c2aaefded2a28ca66f10169dd4170c912538d33fe8690ea549e468e"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
  "miden-assembly",
- "miden-core 0.23.4",
- "miden-crypto 0.25.1",
+ "miden-core 0.29.4",
+ "miden-core-lib",
+ "miden-crypto 0.29.4",
+ "miden-mast-package",
+ "miden-package-registry",
  "miden-protocol",
+ "miden-protocol-build-utils",
  "miden-standards",
- "miden-utils-sync 0.23.4",
- "primitive-types",
- "regex",
+ "miden-utils-sync 0.29.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "walkdir",
 ]
 
 [[package]]
@@ -1939,15 +2536,15 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f1a80330b3e3d3f98e08817dc6a5e3d90d11ab5e88aa9c0dad5d3b4202598b"
+checksum = "84b6d3f3336c8a2da5cd0924c42dd1f339e6c3d5adf3221bc1c005b444fd0bf0"
 dependencies = [
  "miden-ace-codegen",
- "miden-core 0.23.4",
- "miden-crypto 0.25.1",
- "miden-lifted-stark",
- "miden-utils-indexing 0.23.4",
+ "miden-core 0.29.4",
+ "miden-crypto 0.29.4",
+ "miden-utils-indexing 0.29.4",
+ "p3-field 0.6.3",
  "proptest",
  "thiserror 2.0.18",
  "tracing",
@@ -1955,14 +2552,14 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8582d184360be35eb2111a99245f556f43e1066ed09192fbcd0f218c466862a5"
+checksum = "644b31bdda941328f9ff2088382b7de41569c1cc83d6090f63e43d261e9cd262"
 dependencies = [
  "env_logger",
  "log",
  "miden-assembly-syntax",
- "miden-core 0.23.4",
+ "miden-core 0.29.4",
  "miden-mast-package",
  "miden-package-registry",
  "miden-project",
@@ -1973,18 +2570,16 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa307bc2cbd1f0cb74ed58981823f400a433900fb8f963762331fbb8389d5dc"
+checksum = "cad0d5174833b17b498d541d1ef62d73929a143ea56ea5eba719339c15cd0968"
 dependencies = [
- "aho-corasick",
  "env_logger",
- "lalrpop",
- "lalrpop-util",
  "log",
- "miden-core 0.23.4",
- "miden-debug-types 0.23.4",
- "miden-utils-diagnostics 0.23.4",
+ "miden-assembly-syntax-cst",
+ "miden-core 0.29.4",
+ "miden-debug-types 0.29.4",
+ "miden-utils-diagnostics 0.29.4",
  "midenc-hir-type",
  "proptest",
  "proptest-derive",
@@ -1997,10 +2592,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-block-prover"
-version = "0.15.3"
+name = "miden-assembly-syntax-cst"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292ded918a0ddd056dc34db471f0bef6ac7991467d513ba505a4fcc0b1ecfac4"
+checksum = "ff301e56d9201821a4458564ed19ae9b95c7a219662a422e47bb61d17e0fa7b1"
+dependencies = [
+ "miden-debug-types 0.29.4",
+ "miden-rowan",
+ "miden-utils-diagnostics 0.29.4",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "miden-block-prover"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e34859c5f2005e95cfc5ba97ae0dffec15bb44460fc23262532e5e2aee49155"
 dependencies = [
  "miden-protocol",
  "thiserror 2.0.18",
@@ -2008,9 +2615,9 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf89b6ba10e98ffb11d5b644e4c2656f7a220bf367cf0c3b970c2028c1b6a47f"
+checksum = "9f62f7b7382bcb636a9651f678d84ed675adcb428276bd80688b34651f4fa9f1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2020,18 +2627,19 @@ dependencies = [
  "gloo-timers",
  "hex",
  "miden-agglayer",
+ "miden-assembly-syntax",
  "miden-node-proto-build",
  "miden-note-transport-proto-build",
+ "miden-processor 0.29.4",
  "miden-protocol",
- "miden-remote-prover-client",
  "miden-standards",
  "miden-testing",
  "miden-tx",
- "miden-tx-batch-prover",
+ "miden-tx-batch",
  "miette",
  "prost",
  "prost-types",
- "rand 0.9.4",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "tempfile",
@@ -2048,9 +2656,9 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "845f9cd1c93a6bac284ecc7921de5eb9328349dd21dc65b0a4a5d71007693e21"
+checksum = "5e14168a329fae4395e481fb65b3605769f57e08181ee6c053c171e0edcad760"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2063,6 +2671,17 @@ dependencies = [
  "rusqlite_migration",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "miden-constraint-compiler"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ef51ec02f0899c5fc6aa4af11eb050094d98e5e6bf8767a4da555d210f2de6"
+dependencies = [
+ "miden-core 0.29.4",
+ "miden-crypto 0.29.4",
 ]
 
 [[package]]
@@ -2072,7 +2691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66f391ef088343611ad813f6a564a14088d03a17336d350d7f8c60937490f4d"
 dependencies = [
  "derive_more",
- "itertools",
+ "itertools 0.14.0",
  "miden-crypto 0.23.0",
  "miden-debug-types 0.22.4",
  "miden-formatting",
@@ -2086,41 +2705,52 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80657c32850817f5f67dcf114866495a4b055531778b7c26d0602646ce777eb8"
+checksum = "3b27f9f91988c5e74b50b543c4e6d37ec729eabcf70db63cf752dedd780f8a90"
 dependencies = [
  "derive_more",
  "log",
- "miden-crypto 0.25.1",
- "miden-debug-types 0.23.4",
+ "miden-crypto 0.29.4",
+ "miden-debug-types 0.29.4",
  "miden-formatting",
- "miden-utils-core-derive 0.23.4",
- "miden-utils-indexing 0.23.4",
- "miden-utils-sync 0.23.4",
- "num-derive",
- "num-traits",
+ "miden-utils-core-derive 0.29.4",
+ "miden-utils-indexing 0.29.4",
+ "miden-utils-sync 0.29.4",
  "proptest",
- "proptest-derive",
  "serde",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "miden-core-lib"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16410655f32f98537afc9ddf57b71cb6d1ca9d980da5f4eea164cafcaf891b2e"
+checksum = "14df9652fc4963f20d11df9ceb576ccb7831b5dc72fabec5c1b602f51e57909c"
 dependencies = [
  "env_logger",
  "fs-err",
  "miden-assembly",
- "miden-core 0.23.4",
- "miden-crypto 0.25.1",
+ "miden-assembly-syntax",
+ "miden-core 0.29.4",
+ "miden-core-lib-codegen",
+ "miden-crypto 0.29.4",
+ "miden-mast-package",
  "miden-package-registry",
- "miden-processor 0.23.4",
- "miden-utils-sync 0.23.4",
+ "miden-precompiles",
+ "miden-processor 0.29.4",
+ "miden-utils-sync 0.29.4",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "miden-core-lib-codegen"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aad0b8badcf1636150cac0d74aabadd395ba7d570227eb0923ff14f02a278fff"
+dependencies = [
+ "miden-core 0.29.4",
+ "miden-precompiles",
 ]
 
 [[package]]
@@ -2131,82 +2761,80 @@ checksum = "0ed0a034a460e27723dcfdf25effffab84331c3b46b13e7a1bd674197cc71bfe"
 dependencies = [
  "blake3",
  "cc",
- "chacha20poly1305",
- "curve25519-dalek",
- "ed25519-dalek",
- "flume",
+ "chacha20poly1305 0.10.1",
+ "curve25519-dalek 4.1.3",
+ "ed25519-dalek 2.2.0",
+ "flume 0.11.1",
  "glob",
- "hkdf",
- "k256",
+ "hkdf 0.12.4",
+ "k256 0.13.4",
  "miden-crypto-derive 0.23.0",
  "miden-field 0.23.0",
  "miden-serde-utils 0.23.0",
  "num",
  "num-complex",
- "p3-blake3",
- "p3-challenger",
- "p3-dft",
- "p3-goldilocks",
- "p3-keccak",
- "p3-matrix",
- "p3-maybe-rayon",
+ "p3-blake3 0.5.3",
+ "p3-challenger 0.5.3",
+ "p3-dft 0.5.3",
+ "p3-goldilocks 0.5.3",
+ "p3-keccak 0.5.3",
+ "p3-matrix 0.5.3",
+ "p3-maybe-rayon 0.5.3",
  "p3-miden-lifted-stark",
- "p3-symmetric",
- "p3-util",
+ "p3-symmetric 0.5.3",
+ "p3-util 0.5.3",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
  "rand_hc",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "sha3 0.10.9",
  "subtle",
  "thiserror 2.0.18",
- "x25519-dalek",
+ "x25519-dalek 2.0.1",
 ]
 
 [[package]]
 name = "miden-crypto"
-version = "0.25.1"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35198bebd353cddc25ad4aafb5f4ef9e71b283d71c787b8938c575c16974135d"
+checksum = "7c917b0342d911ae4b7a549bb3ca791c093dac4770f88b02e23b43f3fa8179f5"
 dependencies = [
  "blake3",
  "cc",
- "chacha20poly1305",
- "curve25519-dalek",
- "der",
- "ed25519-dalek",
- "flume",
- "hkdf",
- "k256",
- "miden-crypto-derive 0.25.1",
- "miden-field 0.25.1",
+ "chacha20poly1305 0.11.0",
+ "curve25519-dalek 5.0.0",
+ "der 0.8.2",
+ "ed25519-dalek 3.0.0",
+ "flume 0.12.0",
+ "hkdf 0.13.0",
+ "k256 0.14.0",
+ "miden-crypto-derive 0.29.4",
+ "miden-field 0.29.4",
  "miden-lifted-stark",
- "miden-serde-utils 0.25.1",
+ "miden-serde-utils 0.29.4",
  "num",
  "num-complex",
  "once_cell",
- "p3-blake3",
- "p3-challenger",
- "p3-dft",
- "p3-goldilocks",
- "p3-keccak",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-symmetric",
- "p3-util",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
- "rand_hc",
+ "p3-blake3 0.6.3",
+ "p3-challenger 0.6.3",
+ "p3-dft 0.6.3",
+ "p3-goldilocks 0.6.3",
+ "p3-keccak 0.6.3",
+ "p3-matrix 0.6.3",
+ "p3-maybe-rayon 0.6.3",
+ "p3-symmetric 0.6.3",
+ "p3-util 0.6.3",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "rayon",
  "serde",
- "sha2",
- "sha3 0.10.9",
+ "sha2 0.11.0",
+ "sha3 0.12.0",
  "subtle",
  "thiserror 2.0.18",
- "x25519-dalek",
+ "x25519-dalek 3.0.0",
 ]
 
 [[package]]
@@ -2221,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.25.1"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9068c6554db0e051f62913575de9949841a46b96ae92d4b7d28e1fed5d8f052b"
+checksum = "a7c3165dfd7fd6f587ea5731efd1cc8083ca55c23d2d9b3000f83a3948486044"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -2249,21 +2877,22 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956708ccb2f643db398b4b3d4f8d0baf199b1bfb5e34c8be1cd1bc811c005e8e"
+checksum = "4c9f3f8e4a8f54a36fbf00330ac8bd1947627c1786cd49b94a08b741590ed173"
 dependencies = [
  "memchr",
- "miden-crypto 0.25.1",
+ "miden-crypto 0.29.4",
  "miden-formatting",
  "miden-miette",
- "miden-utils-indexing 0.23.4",
- "miden-utils-sync 0.23.4",
+ "miden-utils-indexing 0.29.4",
+ "miden-utils-sync 0.29.4",
  "paste",
  "proptest",
  "serde",
  "serde_spanned",
  "thiserror 2.0.18",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2273,10 +2902,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38011348f4fb4c9e5ce1f471203d024721c00e3b60a91aa91aaefe6738d8b5ea"
 dependencies = [
  "miden-serde-utils 0.23.0",
- "num-bigint",
- "p3-challenger",
- "p3-field",
- "p3-goldilocks",
+ "num-bigint 0.4.6",
+ "p3-challenger 0.5.3",
+ "p3-field 0.5.3",
+ "p3-goldilocks 0.5.3",
  "paste",
  "rand 0.10.1",
  "serde",
@@ -2286,16 +2915,16 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.25.1"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379a39db52cd932a95d4017a18b712ee53ed0f86cfedf8c63ed72d687a18a191"
+checksum = "58cf9de55b88ec86ad272ff4224d76b3e0cbda49e242e78776b0037ba9b0e857"
 dependencies = [
- "miden-serde-utils 0.25.1",
- "num-bigint",
- "p3-challenger",
- "p3-field",
- "p3-goldilocks",
- "p3-util",
+ "miden-serde-utils 0.29.4",
+ "num-bigint 0.5.1",
+ "p3-challenger 0.6.3",
+ "p3-field 0.6.3",
+ "p3-goldilocks 0.6.3",
+ "p3-util 0.6.3",
  "paste",
  "rand 0.10.1",
  "serde",
@@ -2314,34 +2943,35 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.25.1"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789e0e469d1731012d8a018057317f31580611535c20d2a47c022213228cb733"
+checksum = "f67e06d47e246db853a9f3e52ec87fa33a8ffc0fe5be0dd99288b2439312f206"
 dependencies = [
- "p3-air",
- "p3-field",
- "p3-matrix",
- "p3-util",
+ "p3-air 0.6.3",
+ "p3-challenger 0.6.3",
+ "p3-field 0.6.3",
+ "p3-matrix 0.6.3",
+ "p3-util 0.6.3",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.25.1"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62cca91182917b22a47e150028b7c785df620a15b2974a39c64e2b1b7a889d3"
+checksum = "a5ee320597c7712698d06811d9144b0e4f2275a21224ef0238652c947b01198b"
 dependencies = [
  "miden-lifted-air",
  "miden-stark-transcript",
  "miden-stateful-hasher",
- "p3-challenger",
- "p3-dft",
- "p3-field",
- "p3-goldilocks",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-symmetric",
- "p3-util",
+ "p3-challenger 0.6.3",
+ "p3-dft 0.6.3",
+ "p3-field 0.6.3",
+ "p3-goldilocks 0.6.3",
+ "p3-matrix 0.6.3",
+ "p3-maybe-rayon 0.6.3",
+ "p3-symmetric 0.6.3",
+ "p3-util 0.6.3",
  "rand 0.10.1",
  "serde",
  "thiserror 2.0.18",
@@ -2350,15 +2980,20 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37c21836b40785ce297d363c57740d4e33edcc411f84185a524eddadd5f53c7"
+checksum = "1355a2563a52af4399b4a93120a4398f81415b1fc4edb58310de5034cfa3781d"
 dependencies = [
+ "hashbrown 0.17.1",
+ "log",
  "miden-assembly-syntax",
- "miden-core 0.23.4",
- "miden-debug-types 0.23.4",
+ "miden-core 0.29.4",
+ "miden-debug-types 0.29.4",
+ "miden-utils-indexing 0.29.4",
+ "rustc-hash",
  "serde",
  "thiserror 2.0.18",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2399,9 +3034,9 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef3b301741cedd6d0b532583690bc21dbf856d4e14218c591f3924bc905c660a"
+checksum = "724a79e7663157e73de1fc19fcd6e30c7cee4e4c4189d44477922a3969797acb"
 dependencies = [
  "build-rs",
  "codegen",
@@ -2413,9 +3048,9 @@ dependencies = [
 
 [[package]]
 name = "miden-note-transport-proto-build"
-version = "0.4.1"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7399c2999453c781601f16d82f328ecc695f9375e2415a05147449990f32f71f"
+checksum = "5a9d736051a42941788c6534caf8cf779b388c0ae72c9d5f0d729d2a9872d833"
 dependencies = [
  "fs-err",
  "miette",
@@ -2425,12 +3060,12 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ece6064beb0582d1c64ba30d0c548c4b7a45f87abae6d69e22fd49c8b343258"
+checksum = "a799e66245492c193b0444c3e0ff0fe42418009ec668a3e80c40d9f5b1454aac"
 dependencies = [
  "miden-assembly-syntax",
- "miden-core 0.23.4",
+ "miden-core 0.29.4",
  "miden-mast-package",
  "proptest",
  "pubgrub",
@@ -2440,12 +3075,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-precompiles"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "073ebeeb4413b9a03c60b0b066f94b8edaa6f50150017a92dc09d3ace92d6976"
+dependencies = [
+ "miden-core 0.29.4",
+ "miden-crypto 0.29.4",
+]
+
+[[package]]
+name = "miden-precompiles-prover"
+version = "0.29.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76663c4d90cc073f9e2d2aa2349b9dcd25bf6c40db5020d27ce59990b6bd5af"
+dependencies = [
+ "miden-ace-codegen",
+ "miden-air 0.29.4",
+ "miden-core 0.29.4",
+ "miden-crypto 0.29.4",
+ "miden-lifted-air",
+ "miden-lifted-stark",
+ "miden-precompiles",
+ "miden-serde-utils 0.29.4",
+ "ruint",
+ "serde",
+ "serde-wincode",
+ "thiserror 2.0.18",
+ "tracing",
+ "wincode",
+]
+
+[[package]]
 name = "miden-processor"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2c232c8b344f6abbb6a9a58123fe67d190e770f00ec8f4717710d7888813651"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "miden-air 0.22.4",
  "miden-core 0.22.4",
  "miden-debug-types 0.22.4",
@@ -2460,16 +3127,19 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea972ca9e45dbf26aa396367e8508db0f7292adea6f6ddf8d39d0e334285fe2b"
+checksum = "2c7331ab96f00f922d29e2f59285f539299061a44ffdeea31b853d2c071f8056"
 dependencies = [
- "itertools",
- "miden-air 0.23.4",
- "miden-core 0.23.4",
- "miden-debug-types 0.23.4",
- "miden-utils-diagnostics 0.23.4",
- "miden-utils-indexing 0.23.4",
+ "hashbrown 0.17.1",
+ "itertools 0.15.0",
+ "miden-air 0.29.4",
+ "miden-core 0.29.4",
+ "miden-debug-types 0.29.4",
+ "miden-mast-package",
+ "miden-precompiles",
+ "miden-utils-diagnostics 0.29.4",
+ "miden-utils-indexing 0.29.4",
  "paste",
  "rayon",
  "thiserror 2.0.18",
@@ -2478,12 +3148,12 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5320e7e5b562359bd6161ac752dfe43dd4f69bb06e87f94a21a27bb656e5a20d"
+checksum = "6f8201d3a6d0c85c747092309c3c420de42e61e76f71df2189a46411100d120a"
 dependencies = [
  "miden-assembly-syntax",
- "miden-core 0.23.4",
+ "miden-core 0.29.4",
  "miden-mast-package",
  "miden-package-registry",
  "proptest",
@@ -2495,69 +3165,75 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66340243e37da5936cb278a8dd11037813f1dc6731c2fc866703b76ed465ebc3"
+checksum = "89ccf181d3a4e90b9e6ac107547ce1db30f085dfe5696a7735b1de03ac02f6ba"
 dependencies = [
  "bech32",
  "fs-err",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "miden-assembly",
  "miden-assembly-syntax",
- "miden-core 0.23.4",
+ "miden-core 0.29.4",
  "miden-core-lib",
- "miden-crypto 0.25.1",
- "miden-crypto-derive 0.25.1",
+ "miden-crypto 0.29.4",
+ "miden-crypto-derive 0.29.4",
  "miden-mast-package",
- "miden-processor 0.23.4",
- "miden-utils-sync 0.23.4",
+ "miden-package-registry",
+ "miden-processor 0.29.4",
+ "miden-protocol-build-utils",
+ "miden-utils-sync 0.29.4",
  "miden-verifier",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "rand_xoshiro",
  "regex",
  "semver 1.0.28",
  "serde",
  "thiserror 2.0.18",
  "toml",
+]
+
+[[package]]
+name = "miden-protocol-build-utils"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d16cdd96c1d0b3b2d57342d37eaadd15cc7c633bda965fc8c3b23ca249965b4"
+dependencies = [
+ "fs-err",
+ "miden-assembly",
+ "miden-core 0.29.4",
+ "miden-mast-package",
+ "miden-package-registry",
+ "miden-project",
+ "regex",
  "walkdir",
 ]
 
 [[package]]
 name = "miden-prover"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a91bcc00840b01126cd54e3b68ce3235def2ed48803f2eeb36a035d6951fbc1"
+checksum = "b20c4cabb7a032e7613adff4c637c267bbcaad0d0fa37f7c7addbe7d425bb5c4"
 dependencies = [
- "bincode",
- "miden-air 0.23.4",
- "miden-core 0.23.4",
- "miden-crypto 0.25.1",
- "miden-processor 0.23.4",
+ "miden-air 0.29.4",
+ "miden-core 0.29.4",
+ "miden-crypto 0.29.4",
+ "miden-precompiles-prover",
+ "miden-processor 0.29.4",
  "serde",
+ "serde-wincode",
  "tracing",
 ]
 
 [[package]]
-name = "miden-remote-prover-client"
-version = "0.15.0"
+name = "miden-rowan"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2acdb9494689feeec0f60e3b61901b5eb2362b49b993b4cbc3eb75ad83514dd"
+checksum = "c13695bf99aabaa21d6572b807c66bb26251aa3d9b75e828b3c99b97a3b1ce7e"
 dependencies = [
- "build-rs",
- "fs-err",
- "getrandom 0.4.3",
- "miden-node-proto-build",
- "miden-protocol",
- "miden-tx",
- "miette",
- "prost",
- "thiserror 2.0.18",
- "tokio",
- "tonic",
- "tonic-prost",
- "tonic-prost-build",
- "tonic-web-wasm-client",
+ "hashbrown 0.17.1",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -2566,102 +3242,107 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff78082e9b4ca89863e68da01b35f8a4029ee6fd912e39fa41fde4273a7debab"
 dependencies = [
- "p3-field",
- "p3-goldilocks",
+ "p3-field 0.5.3",
+ "p3-goldilocks 0.5.3",
 ]
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.25.1"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78cd1d4fcad937312e544f7d53423485e453598aa4fb989d2b6374027a8c136"
+checksum = "f5c21a2acdc1928f86803b3ff3c44564c3f614a7dc47dcd64969a5c856d27988"
 dependencies = [
- "p3-field",
- "p3-goldilocks",
+ "p3-field 0.6.3",
+ "p3-goldilocks 0.6.3",
+ "wincode",
 ]
 
 [[package]]
 name = "miden-standards"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c7146b028e637f4079b5bdefeefc54d7d6e47a805451fa0a18859d19efa2ff"
+checksum = "ee6fc2cdac6d1bb48ae4b0c2f0498e754490750283783b7a71b25c3017e68754"
 dependencies = [
  "bon",
- "fs-err",
  "miden-assembly",
  "miden-core-lib",
+ "miden-package-registry",
  "miden-protocol",
- "rand 0.9.4",
- "regex",
+ "miden-protocol-build-utils",
+ "primitive-types 0.14.0",
+ "rand 0.10.1",
  "thiserror 2.0.18",
- "walkdir",
 ]
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.25.1"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05901db2e30d3954243960fe21cea7fbec39f97c27774b56fd5031c28c4881ba"
+checksum = "d503630c353389838fa5d668a0d4550130453c7b2a72b802d4adc1ea39ab5bee"
 dependencies = [
- "p3-challenger",
- "p3-field",
+ "p3-challenger 0.6.3",
+ "p3-field 0.6.3",
  "serde",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.25.1"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faeb47a90c55c5d45051d23cf691588804dd531995b4582c79108b64e445a905"
+checksum = "e8c2008195bdb552eeb744074bfc8822049552ccdf7aef3321a32e1ab6be92e6"
 dependencies = [
- "p3-field",
- "p3-symmetric",
+ "p3-field 0.6.3",
+ "p3-symmetric 0.6.3",
 ]
 
 [[package]]
 name = "miden-testing"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4096fc44a4c88f37405be284e25efdce194d6051e9472ae136ab9249659433c"
+checksum = "697ea989c4553c1676dd740e41ad29d35fa6b1ac2ab20893c647fa4c7ec6d9dd"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.15.0",
  "miden-block-prover",
  "miden-core-lib",
- "miden-crypto 0.25.1",
- "miden-processor 0.23.4",
+ "miden-crypto 0.29.4",
+ "miden-processor 0.29.4",
  "miden-protocol",
  "miden-standards",
  "miden-tx",
- "miden-tx-batch-prover",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
+ "miden-tx-batch",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "miden-tx"
-version = "0.15.3"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94092b45bc0abc656af25473c9807d1e6cee8e682c58d3b1186f0bd0fb6471fb"
+checksum = "6d5e8e69cf0db2d2f37f16909fc17d0b28730e1d21a587580ec90f27e19e309f"
 dependencies = [
- "miden-processor 0.23.4",
+ "bon",
+ "miden-agglayer",
+ "miden-processor 0.29.4",
  "miden-protocol",
  "miden-prover",
  "miden-standards",
- "miden-verifier",
  "thiserror 2.0.18",
 ]
 
 [[package]]
-name = "miden-tx-batch-prover"
-version = "0.15.3"
+name = "miden-tx-batch"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60add2b40559352661bc86970541f88ffcf98c528f301295f9dc3bf15481b46"
+checksum = "06419d4c747d8e79674d2be1436f0a46abe70aa2598f1789e71a07c14106cfa9"
 dependencies = [
+ "miden-processor 0.29.4",
  "miden-protocol",
- "miden-tx",
+ "miden-prover",
+ "miden-verifier",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2677,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b1ee4662beb049a824e11bb21f95a79746c52874967983c9999f1b19a2f471"
+checksum = "107d04fcd05b0308e6347113ee6dc13599755e5b4d05ecc08d8b5c05f36a5a39"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2701,12 +3382,11 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fdc1cd4eda372e1c4b99b9c3677e9b1f87a4d2e362a9f4b8f904273d395efc9"
+checksum = "f3b444d204bf082cdab14015ff10d5b0b43a10fba662fef09e4753f6d07faf1f"
 dependencies = [
- "miden-crypto 0.25.1",
- "miden-debug-types 0.23.4",
+ "miden-debug-types 0.29.4",
  "miden-miette",
  "tracing",
 ]
@@ -2723,11 +3403,11 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31444125649f4dad9cde647f614309b6be4f918fed276ada4eb99c01e8b9ca7"
+checksum = "f6ff225060e2a5cc4dd6c898eef1f04739461d3401b6de1692bf443cfdd302b0"
 dependencies = [
- "miden-crypto 0.25.1",
+ "miden-serde-utils 0.29.4",
  "proptest",
  "serde",
  "thiserror 2.0.18",
@@ -2747,9 +3427,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807c8ae625b7652ae7246b225c907c05da72927c31a0fd71c835c4f80931e92e"
+checksum = "76b9cb00f01787f8687447cd8a45b3888b470eb35a132df1be9729779d311fd7"
 dependencies = [
  "lock_api",
  "loom",
@@ -2759,27 +3439,29 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.23.4"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5556dac919a1c13edeb2bd7181fc6a4c2ce52764a3e518bcdcd9ed48e5b38e"
+checksum = "5e049df6008af1fea5a66df8ce98075cc9e00f16122fd5f4e7c4be9a263cae46"
 dependencies = [
- "bincode",
- "miden-air 0.23.4",
- "miden-core 0.23.4",
- "miden-crypto 0.25.1",
+ "miden-air 0.29.4",
+ "miden-core 0.29.4",
+ "miden-crypto 0.29.4",
+ "miden-precompiles",
+ "miden-precompiles-prover",
+ "miden-serde-utils 0.29.4",
  "serde",
+ "serde-wincode",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.6.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff0511aa2201f7098995e38a3c97a319d379c3b2d26fb83677b21b71f61a7b4"
+checksum = "dcdf2257de8f3486c8f3e93c45219b782bafad62a8694798c05d5b8f3f79c64e"
 dependencies = [
  "miden-formatting",
- "miden-serde-utils 0.25.1",
+ "miden-serde-utils 0.29.4",
  "serde",
  "serde_repr",
  "smallvec",
@@ -2852,18 +3534,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2872,7 +3548,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -2885,6 +3561,16 @@ name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2936,7 +3622,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
 ]
@@ -3010,8 +3696,19 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c824e8d7c7ddf208b742eac8d48e0b2d52d22fa013578a7762bf6931dbab1f46"
 dependencies = [
- "p3-field",
- "p3-matrix",
+ "p3-field 0.5.3",
+ "p3-matrix 0.5.3",
+ "tracing",
+]
+
+[[package]]
+name = "p3-air"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb1be05c0d6f691afe0c9f468018a9a37cfa904dee78a8081ec96eb3cdd88e8"
+dependencies = [
+ "p3-field 0.6.3",
+ "p3-matrix 0.6.3",
  "tracing",
 ]
 
@@ -3022,8 +3719,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2733229a713bd83ccf5eb749e8f8e7380c1052674394a25c0422a772204a20af"
 dependencies = [
  "blake3",
- "p3-symmetric",
- "p3-util",
+ "p3-symmetric 0.5.3",
+ "p3-util 0.5.3",
+]
+
+[[package]]
+name = "p3-blake3"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f202f5fbcceb6f56f783d98efb5de27e5a171470e3364de97b0923b39c87ab5"
+dependencies = [
+ "blake3",
+ "p3-symmetric 0.6.3",
+ "p3-util 0.6.3",
 ]
 
 [[package]]
@@ -3032,11 +3740,25 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8972ccd1d5dc90e46cdb1f2ab4ee2bae49b3917e5e98aa533f0c2b779c010445"
 dependencies = [
- "p3-field",
- "p3-maybe-rayon",
- "p3-monty-31",
- "p3-symmetric",
- "p3-util",
+ "p3-field 0.5.3",
+ "p3-maybe-rayon 0.5.3",
+ "p3-monty-31 0.5.3",
+ "p3-symmetric 0.5.3",
+ "p3-util 0.5.3",
+ "tracing",
+]
+
+[[package]]
+name = "p3-challenger"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d5d5e1ecf2c80b09b48ce870e8abd08b643454101c5dc9d0fd71bfbd78224d"
+dependencies = [
+ "p3-field 0.6.3",
+ "p3-maybe-rayon 0.6.3",
+ "p3-monty-31 0.6.3",
+ "p3-symmetric 0.6.3",
+ "p3-util 0.6.3",
  "tracing",
 ]
 
@@ -3046,10 +3768,10 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5451768a715d8b7a30e64e23f5f78d3d37880ff18aedaa337181acece89b5e4"
 dependencies = [
- "itertools",
- "p3-field",
- "p3-matrix",
- "p3-util",
+ "itertools 0.14.0",
+ "p3-field 0.5.3",
+ "p3-matrix 0.5.3",
+ "p3-util 0.5.3",
  "serde",
 ]
 
@@ -3059,12 +3781,27 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17771aca44632f9cc11f2718d7ea7ec06794946c4190ef3a985bfc893f14c18a"
 dependencies = [
- "itertools",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-util",
+ "itertools 0.14.0",
+ "p3-field 0.5.3",
+ "p3-matrix 0.5.3",
+ "p3-maybe-rayon 0.5.3",
+ "p3-util 0.5.3",
  "spin 0.10.0",
+ "tracing",
+]
+
+[[package]]
+name = "p3-dft"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321a952da2721ecd85ca593ea189798dfb4e439a2cc1378ce1442091880f173"
+dependencies = [
+ "itertools 0.15.0",
+ "p3-field 0.6.3",
+ "p3-matrix 0.6.3",
+ "p3-maybe-rayon 0.6.3",
+ "p3-util 0.6.3",
+ "spin 0.12.3",
  "tracing",
 ]
 
@@ -3074,10 +3811,26 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f3eb24d0591fd4d282d89cbe4e4efba5571c699375006f80b2cbf53ce83461c"
 dependencies = [
- "itertools",
- "num-bigint",
- "p3-maybe-rayon",
- "p3-util",
+ "itertools 0.14.0",
+ "num-bigint 0.4.6",
+ "p3-maybe-rayon 0.5.3",
+ "p3-util 0.5.3",
+ "paste",
+ "rand 0.10.1",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53db75d38e04fc255826f388eca9d05976733dc9754aa3db411bc9ea1a37c1a0"
+dependencies = [
+ "itertools 0.15.0",
+ "num-bigint 0.5.1",
+ "p3-maybe-rayon 0.6.3",
+ "p3-util 0.6.3",
  "paste",
  "rand 0.10.1",
  "serde",
@@ -3090,18 +3843,39 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5751c6591a0d2397d726620c2c29a7436ec6c5e19d2ed74ca5d078d4fbb18eb5"
 dependencies = [
- "num-bigint",
- "p3-challenger",
- "p3-dft",
- "p3-field",
- "p3-mds",
- "p3-poseidon1",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-util",
+ "num-bigint 0.4.6",
+ "p3-challenger 0.5.3",
+ "p3-dft 0.5.3",
+ "p3-field 0.5.3",
+ "p3-mds 0.5.3",
+ "p3-poseidon1 0.5.3",
+ "p3-poseidon2 0.5.3",
+ "p3-symmetric 0.5.3",
+ "p3-util 0.5.3",
  "paste",
  "rand 0.10.1",
  "serde",
+]
+
+[[package]]
+name = "p3-goldilocks"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03b3f31080df31be723b876709246f8f1e532e1c5b82efb5281d705c8304c63"
+dependencies = [
+ "num-bigint 0.5.1",
+ "p3-challenger 0.6.3",
+ "p3-dft 0.6.3",
+ "p3-field 0.6.3",
+ "p3-mds 0.6.3",
+ "p3-poseidon1 0.6.3",
+ "p3-poseidon2 0.6.3",
+ "p3-symmetric 0.6.3",
+ "p3-util 0.6.3",
+ "paste",
+ "rand 0.10.1",
+ "serde",
+ "spin 0.12.3",
 ]
 
 [[package]]
@@ -3110,8 +3884,19 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a7df174ff0c19a8742eb4698eaa1667c5f858d018e2faf09c55f1f24a6f9c3"
 dependencies = [
- "p3-symmetric",
- "p3-util",
+ "p3-symmetric 0.5.3",
+ "p3-util 0.5.3",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "p3-keccak"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae50c8c37eb847c660298fb275e53c025c49b2623a8cfabf67f5322258b2b4db"
+dependencies = [
+ "p3-symmetric 0.6.3",
+ "p3-util 0.6.3",
  "tiny-keccak",
 ]
 
@@ -3121,10 +3906,25 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea9c94c0714944e7b8a9a62e6340b1e3e1d3f8ecfd3e35c08798360200e73eff"
 dependencies = [
- "itertools",
- "p3-field",
- "p3-maybe-rayon",
- "p3-util",
+ "itertools 0.14.0",
+ "p3-field 0.5.3",
+ "p3-maybe-rayon 0.5.3",
+ "p3-util 0.5.3",
+ "rand 0.10.1",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473eb920c446a6f4536e0d3528fbdca2a23c0e24e1d0d7767452e6d385dd335c"
+dependencies = [
+ "itertools 0.15.0",
+ "p3-field 0.6.3",
+ "p3-maybe-rayon 0.6.3",
+ "p3-util 0.6.3",
  "rand 0.10.1",
  "serde",
  "tracing",
@@ -3135,6 +3935,12 @@ name = "p3-maybe-rayon"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebc233a34b1ab0273f35b4052fa2eeb3114b22ba4575bd7da00716e878ffb77"
+
+[[package]]
+name = "p3-maybe-rayon"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6fddfd435f96394769414cf5590b77058aa506659bf20d6592e9d1989e04440"
 dependencies = [
  "rayon",
 ]
@@ -3145,10 +3951,23 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b5441fa8116246ec9e6c835f15273cb27777ca572960ec87476b67fef13e01e"
 dependencies = [
- "p3-dft",
- "p3-field",
- "p3-symmetric",
- "p3-util",
+ "p3-dft 0.5.3",
+ "p3-field 0.5.3",
+ "p3-symmetric 0.5.3",
+ "p3-util 0.5.3",
+ "rand 0.10.1",
+]
+
+[[package]]
+name = "p3-mds"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551ba0ab2cccd89f85a99450224898aff224e323bbf61f777ba6344f0896ef10"
+dependencies = [
+ "p3-dft 0.6.3",
+ "p3-field 0.6.3",
+ "p3-symmetric 0.6.3",
+ "p3-util 0.6.3",
  "rand 0.10.1",
 ]
 
@@ -3158,10 +3977,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5c31c65fdc88952d7b301546add9670676e5b878aa0066dd929f107c203b006"
 dependencies = [
- "p3-air",
- "p3-field",
- "p3-matrix",
- "p3-util",
+ "p3-air 0.5.3",
+ "p3-field 0.5.3",
+ "p3-matrix 0.5.3",
+ "p3-util 0.5.3",
  "thiserror 2.0.18",
 ]
 
@@ -3171,15 +3990,15 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab9932f1b0a16609a45cd4ee10a4d35412728bc4b38837c7979d7c85d8dcc9fc"
 dependencies = [
- "p3-challenger",
+ "p3-challenger 0.5.3",
  "p3-commit",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
+ "p3-dft 0.5.3",
+ "p3-field 0.5.3",
+ "p3-matrix 0.5.3",
+ "p3-maybe-rayon 0.5.3",
  "p3-miden-lmcs",
  "p3-miden-transcript",
- "p3-util",
+ "p3-util 0.5.3",
  "rand 0.10.1",
  "thiserror 2.0.18",
  "tracing",
@@ -3191,17 +4010,17 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3956ab7270c3cdd53ca9796d39ae1821984eb977415b0672110f9666bff5d8"
 dependencies = [
- "p3-challenger",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
+ "p3-challenger 0.5.3",
+ "p3-dft 0.5.3",
+ "p3-field 0.5.3",
+ "p3-matrix 0.5.3",
+ "p3-maybe-rayon 0.5.3",
  "p3-miden-lifted-air",
  "p3-miden-lifted-fri",
  "p3-miden-lmcs",
  "p3-miden-stateful-hasher",
  "p3-miden-transcript",
- "p3-util",
+ "p3-util 0.5.3",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -3213,13 +4032,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c46791c983e772136db3d48f102431457451447abb9087deb6c8ce3c1efc86"
 dependencies = [
  "p3-commit",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
+ "p3-field 0.5.3",
+ "p3-matrix 0.5.3",
+ "p3-maybe-rayon 0.5.3",
  "p3-miden-stateful-hasher",
  "p3-miden-transcript",
- "p3-symmetric",
- "p3-util",
+ "p3-symmetric 0.5.3",
+ "p3-util 0.5.3",
  "rand 0.10.1",
  "serde",
  "thiserror 2.0.18",
@@ -3232,8 +4051,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec47a9d9615eb3d9d2a59b00d19751d9ad85384b55886827913d680d912eac6a"
 dependencies = [
- "p3-field",
- "p3-symmetric",
+ "p3-field 0.5.3",
+ "p3-symmetric 0.5.3",
 ]
 
 [[package]]
@@ -3242,8 +4061,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c565647487e4a949f67e6f115b0391d6cb82ac8e561165789939bab23d0ae7"
 dependencies = [
- "p3-challenger",
- "p3-field",
+ "p3-challenger 0.5.3",
+ "p3-field 0.5.3",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -3254,21 +4073,45 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8724f330ea6d19dd4f2436aa0f88b5fcbf88f0f55ca7fccd3fea8b736dbcddad"
 dependencies = [
- "itertools",
- "num-bigint",
- "p3-dft",
- "p3-field",
- "p3-matrix",
- "p3-maybe-rayon",
- "p3-mds",
- "p3-poseidon1",
- "p3-poseidon2",
- "p3-symmetric",
- "p3-util",
+ "itertools 0.14.0",
+ "num-bigint 0.4.6",
+ "p3-dft 0.5.3",
+ "p3-field 0.5.3",
+ "p3-matrix 0.5.3",
+ "p3-maybe-rayon 0.5.3",
+ "p3-mds 0.5.3",
+ "p3-poseidon1 0.5.3",
+ "p3-poseidon2 0.5.3",
+ "p3-symmetric 0.5.3",
+ "p3-util 0.5.3",
  "paste",
  "rand 0.10.1",
  "serde",
  "spin 0.10.0",
+ "tracing",
+]
+
+[[package]]
+name = "p3-monty-31"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "871f635f7340cd0868b17e43e0c98fefdafdaed90469d0725caf6d8372a2a47c"
+dependencies = [
+ "itertools 0.15.0",
+ "num-bigint 0.5.1",
+ "p3-dft 0.6.3",
+ "p3-field 0.6.3",
+ "p3-matrix 0.6.3",
+ "p3-maybe-rayon 0.6.3",
+ "p3-mds 0.6.3",
+ "p3-poseidon1 0.6.3",
+ "p3-poseidon2 0.6.3",
+ "p3-symmetric 0.6.3",
+ "p3-util 0.6.3",
+ "paste",
+ "rand 0.10.1",
+ "serde",
+ "spin 0.12.3",
  "tracing",
 ]
 
@@ -3278,8 +4121,20 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04e2a562fea210baae390a32f9ecf0dd8724ae3f4352d1c8e413077b6f00a162"
 dependencies = [
- "p3-field",
- "p3-symmetric",
+ "p3-field 0.5.3",
+ "p3-symmetric 0.5.3",
+ "rand 0.10.1",
+]
+
+[[package]]
+name = "p3-poseidon1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d0d304e9a1f29c0d66534aa84e69528e2118351fdce08dcf5898af4e0fecc32"
+dependencies = [
+ "p3-field 0.6.3",
+ "p3-mds 0.6.3",
+ "p3-symmetric 0.6.3",
  "rand 0.10.1",
 ]
 
@@ -3289,10 +4144,23 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06394851c161d17e4aa4ad2aad5557d32f14cadd1dc838f965d8e1821a63b8c5"
 dependencies = [
- "p3-field",
- "p3-mds",
- "p3-symmetric",
- "p3-util",
+ "p3-field 0.5.3",
+ "p3-mds 0.5.3",
+ "p3-symmetric 0.5.3",
+ "p3-util 0.5.3",
+ "rand 0.10.1",
+]
+
+[[package]]
+name = "p3-poseidon2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43eb8a73a26d14becaed1c67c3e8a047e4311d7909b402383c82ca9643ba17c6"
+dependencies = [
+ "p3-field 0.6.3",
+ "p3-mds 0.6.3",
+ "p3-symmetric 0.6.3",
+ "p3-util 0.6.3",
  "rand 0.10.1",
 ]
 
@@ -3302,9 +4170,21 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ac1a276d421f8ef3361bb7d8c39a02c93c6b3f10eeaa559cc4c50222f9a5b82"
 dependencies = [
- "itertools",
- "p3-field",
- "p3-util",
+ "itertools 0.14.0",
+ "p3-field 0.5.3",
+ "p3-util 0.5.3",
+ "serde",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2015ea80cad969b6aabf27a04884286fe1354393b166d968ee0d80a95126b2a4"
+dependencies = [
+ "itertools 0.15.0",
+ "p3-field 0.6.3",
+ "p3-util 0.6.3",
  "serde",
 ]
 
@@ -3314,9 +4194,46 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d08a58162a4c264269ef454f0b28dcda89939490eecacb2b2cf5b00f719b80f6"
 dependencies = [
- "rayon",
  "serde",
  "transpose",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5466fc40e6df89d3b291a2eff16b33e68e8571207790370137ec18090aadab"
+dependencies = [
+ "rayon",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3349,19 +4266,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "petgraph"
-version = "0.7.1"
+name = "pest"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "6d45aeb61b4bf818e12d4205f2466f8c4748f85f4fce0146d1c03d69d753f0ad"
 dependencies = [
- "fixedbitset",
- "indexmap",
+ "memchr",
+ "ucd-trie",
 ]
 
 [[package]]
@@ -3373,15 +4296,6 @@ dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
  "indexmap",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -3416,8 +4330,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.2",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -3428,7 +4352,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pm-accounts"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.11"
 dependencies = [
  "anyhow",
  "miden-client",
@@ -3440,8 +4364,8 @@ dependencies = [
  "once_cell",
  "pm-types",
  "pm-utils-cli",
- "rand 0.9.4",
- "rand_chacha 0.3.1",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
  "tempfile",
  "tokio",
  "uuid",
@@ -3449,7 +4373,7 @@ dependencies = [
 
 [[package]]
 name = "pm-oracle-cli"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3466,7 +4390,7 @@ dependencies = [
  "pm-utils-cli",
  "prettytable-rs",
  "pyo3",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3476,7 +4400,7 @@ dependencies = [
 
 [[package]]
 name = "pm-publisher-cli"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3494,7 +4418,7 @@ dependencies = [
  "prettytable-rs",
  "pyo3",
  "pyo3-build-config",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rusqlite",
  "serde_json",
  "thiserror 1.0.69",
@@ -3503,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "pm-types"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.11"
 dependencies = [
  "anyhow",
  "miden-client",
@@ -3511,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "pm-utils-cli"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3522,7 +4446,7 @@ dependencies = [
  "miden-protocol",
  "miden-tx",
  "pm-types",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3539,7 +4463,17 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -3567,12 +4501,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3592,8 +4520,45 @@ dependencies = [
  "encode_unicode",
  "is-terminal",
  "lazy_static",
- "term 0.7.0",
+ "term",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "serdect",
+ "wnaf",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint 0.9.5",
 ]
 
 [[package]]
@@ -3603,7 +4568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "721a1da530b5a2633218dc9f75713394c983c352be88d2d7c9ee85e2c4c21794"
 dependencies = [
  "fixed-hash",
- "uint",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -3615,6 +4580,15 @@ dependencies = [
  "equivalent",
  "indexmap",
  "serde",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -3690,11 +4664,11 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph 0.8.3",
+ "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
@@ -3712,7 +4686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -3885,11 +4859,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -3909,6 +4891,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
+ "chacha20 0.10.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -3930,6 +4914,16 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3976,11 +4970,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+checksum = "662effc7698e08ea324d3acccf8d9d7f7bf79b9785e270a174ea36e56900c91d"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4058,8 +5052,18 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -4077,14 +5081,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
 name = "ruint"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.6",
  "rand 0.9.4",
+ "rlp",
  "ruint-macro",
  "serde_core",
  "valuable",
@@ -4134,12 +5161,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -4161,7 +5203,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4259,10 +5301,24 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.2",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -4296,7 +5352,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.3",
 ]
 
 [[package]]
@@ -4314,6 +5379,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -4335,6 +5409,17 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "serde-wincode"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa9d3a86c66cf10ce79df36f555a5a4c8d72a82515d9ea8ca420e02c925c30f"
+dependencies = [
+ "serde",
+ "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -4391,6 +5476,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4399,6 +5494,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4419,6 +5525,17 @@ checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.3",
  "keccak 0.2.0",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -4447,10 +5564,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "1.0.3"
+name = "signature"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "slab"
@@ -4502,14 +5623,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0134f9043ed38b087ac4f7d4af44c79e2c9e5094421fe3164f435ce585953b10"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.2",
+]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "static_assertions"
@@ -4522,18 +5668,6 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
-
-[[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
-]
 
 [[package]]
 name = "strip-ansi-escapes"
@@ -4600,6 +5734,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn-solidity"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4616,6 +5761,12 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -4639,7 +5790,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4651,15 +5802,6 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
-]
-
-[[package]]
-name = "term"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
-dependencies = [
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4678,7 +5820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4833,6 +5975,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -5094,6 +6248,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "uint"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5167,6 +6339,16 @@ checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -5363,7 +6545,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5371,6 +6553,18 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wincode"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc6339f1ba427bf7ad7c42403b28e524832ba2ddb5eef1bb2cc3b85db6b7b75"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "windows-core"
@@ -5527,6 +6721,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -5535,13 +6732,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wnaf"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "795ca18b3fdb5e62bf982199278341ddcf7ebf7d32e25e212ad05d496e95f6fa"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+ "primefield",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x25519-dalek"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5569,6 +6797,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 unsafe_code = "forbid"
 
 [workspace.package]
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.11"
 authors = ["Pragma <https://github.com/astraly-labs>"]
 homepage = "https://www.pragma.build/"
 edition = "2021"
@@ -36,8 +36,8 @@ pm-utils-cli = { path = "crates/cli/utils", default-features = false }
 
 anyhow = "1.0.93"
 async-trait = "0.1.83"
-rand = { version = "0.9", default-features = false }
-rand_chacha = { version = "0.3", default-features = false }
+rand = { version = "0.10", default-features = false }
+rand_chacha = { version = "0.10", default-features = false }
 lazy_static = "1.5.0"
 clap = { version = "4.5.22", features = ["derive"] }
 colored = "2.1.0"
@@ -50,16 +50,16 @@ chrono = "0.4"
 prettytable-rs = "0.10"
 futures = "0.3.31"
 # Miden 0.15 dependencies
-miden-protocol = { version = "0.15" }
-miden-standards = { version = "0.15" }
-miden-assembly = "0.23"
-miden-core = "0.23"
-miden-core-lib = "0.23"
-miden-crypto = "0.25"
-miden-tx = { version = "0.15", features = ["concurrent"] }
-miden-testing = { version = "0.15" }
-miden-client = { version = "0.15", features = ["tonic", "testing"] }
-miden-client-sqlite-store = "0.15"
+miden-protocol = { version = "0.16" }
+miden-standards = { version = "0.16" }
+miden-assembly = "0.29"
+miden-core = "0.29"
+miden-core-lib = "0.29"
+miden-crypto = "0.29"
+miden-tx = { version = "0.16", features = ["concurrent"] }
+miden-testing = { version = "0.16" }
+miden-client = { version = "0.16", features = ["tonic", "testing"] }
+miden-client-sqlite-store = "0.16"
 
 pyo3 = { version = "0.20.0", features = ["extension-module",  "abi3-py37"] }
 uuid = { version = "1.10", features = ["serde", "v4"] }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Deployments
 
-### Testnet (Miden 0.15)
+### Testnet (Miden 0.16)
 
 | Role       | Account ID                           | Explorer |
 |------------|--------------------------------------|----------|

--- a/crates/accounts/src/oracle/mod.rs
+++ b/crates/accounts/src/oracle/mod.rs
@@ -1,12 +1,9 @@
 use std::sync::Arc;
 
-use rand::Rng;
+use rand::RngExt;
 
 use miden_client::{
-    account::{
-        component::{AuthScheme, AuthSingleSig},
-        Account, AccountType as ClientAccountType,
-    },
+    account::{component::AuthSingleSig, Account, AccountType as ClientAccountType},
     auth::AuthSecretKey,
     crypto::rpo_falcon512::SecretKey,
     keystore::{FilesystemKeyStore, Keystore},
@@ -14,13 +11,12 @@ use miden_client::{
 };
 use miden_protocol::{
     account::{
-        AccountBuilder, AccountComponent, AccountComponentMetadata, StorageSlot, StorageSlotName,
+        AccountBuilder, AccountComponent, AccountComponentCode, AccountComponentMetadata,
+        StorageSlot, StorageSlotName,
     },
-    assembly::{DefaultSourceManager, Library, Module, ModuleKind, Path as LibraryPath},
-    transaction::TransactionKernel,
+    assembly::Package,
 };
-
-use miden_protocol::assembly::mast::MastNodeExt;
+use miden_standards::code_builder::CodeBuilder;
 
 use crate::publisher::get_entry_procedure_hash;
 
@@ -42,38 +38,25 @@ pub fn oracle_storage_slots() -> Vec<StorageSlot> {
     ]
 }
 
-pub fn get_oracle_component_library() -> Arc<Library> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let oracle_masm = get_oracle_masm();
-    let oracle_component_module = Module::parser(ModuleKind::Library)
-        .parse_str(
-            LibraryPath::new("oracle_component::oracle_module"),
-            &oracle_masm,
-            source_manager.clone(),
-        )
-        .unwrap();
-    TransactionKernel::assembler_with_source_manager(source_manager)
-        .assemble_library([oracle_component_module])
+pub const ORACLE_MODULE_PATH: &str = "oracle_component::oracle_module";
+
+/// Compiles the oracle MASM (with the publisher `get_entry` hash injected) into
+/// an account component code.
+pub fn get_oracle_component_code() -> AccountComponentCode {
+    CodeBuilder::new()
+        .compile_component_code(ORACLE_MODULE_PATH, get_oracle_masm())
         .expect("assembly should succeed")
+}
+
+pub fn get_oracle_component_library() -> Arc<Package> {
+    Arc::new(get_oracle_component_code().into_package())
 }
 
 pub fn get_median_procedure_hash() -> String {
     let lib = get_oracle_component_library();
-    let export = lib
-        .exports()
-        .find(|e| {
-            let path = e.path();
-            let path_str = path.as_ref().as_str();
-            path_str.ends_with("::get_median") || path_str == "get_median"
-        })
-        .expect("get_median procedure not found in oracle library");
-
-    let node_id = lib.get_export_node_id(export.path());
     let digest = lib
-        .mast_forest()
-        .get_node_by_id(node_id)
-        .expect("node not found")
-        .digest();
+        .get_procedure_root_by_path(format!("{ORACLE_MODULE_PATH}::get_median").as_str())
+        .expect("get_median procedure not found in oracle library");
 
     digest
         .as_elements()
@@ -84,11 +67,13 @@ pub fn get_median_procedure_hash() -> String {
 }
 
 pub fn get_oracle_component() -> AccountComponent {
-    let library = get_oracle_component_library();
-    let library = Arc::try_unwrap(library).unwrap_or_else(|arc| (*arc).clone());
     let metadata = AccountComponentMetadata::new("pragma::oracle");
-    AccountComponent::new(library, oracle_storage_slots(), metadata)
-        .expect("assembly should succeed")
+    AccountComponent::new(
+        get_oracle_component_code(),
+        oracle_storage_slots(),
+        metadata,
+    )
+    .expect("assembly should succeed")
 }
 
 pub struct OracleAccountBuilder<'a> {
@@ -140,15 +125,12 @@ impl<'a> OracleAccountBuilder<'a> {
         let private_key = SecretKey::with_rng(client_rng);
         let public_key = private_key.public_key();
 
-        let auth_component = AuthSingleSig::new(
-            public_key.to_commitment().into(),
-            AuthScheme::Falcon512Poseidon2,
-        );
+        let auth_component = AuthSingleSig::falcon512_poseidon2(public_key);
         let from_seed = client_rng.random();
 
         let account = AccountBuilder::new(from_seed)
             .account_type(account_type)
-            .with_auth_component(auth_component)
+            .with_component(auth_component)
             .with_component(oracle_component)
             .build()
             .unwrap();

--- a/crates/accounts/src/oracle/oracle.masm
+++ b/crates/accounts/src/oracle/oracle.masm
@@ -269,6 +269,7 @@ end
 #!
 #! Inputs:  [PUBLISHER_ID, faucet_id_word]
 #! Outputs: [ENTRY]
+@account_procedure
 pub proc get_entry
     # Verifies if the publisher is registered, panics if not
     # dupw push.PUBLISHER_REGISTRY_MAP_SLOT[0..2] exec.active_account::get_map_item dropw
@@ -288,6 +289,7 @@ end
 #!
 #! Inputs:  [faucet_id_prefix, faucet_id_suffix, amount, 0]
 #! Outputs: [is_tracked, median_price]
+@account_procedure
 pub proc get_median
 
     # => [faucet_id_prefix, faucet_id_suffix, amount, 0]
@@ -403,6 +405,7 @@ end
 #!
 #! Inputs:  [PUBLISHER_ID]
 #! Outputs: []
+@account_procedure
 pub proc register_publisher
 
     # => [prefix, suffix, 0, 0]
@@ -479,6 +482,7 @@ end
 #!
 #! Inputs:  [PUBLISHER_ID]
 #! Outputs: []
+@account_procedure
 pub proc remove_publisher
 
     # => [prefix, suffix, 0, 0]

--- a/crates/accounts/src/publisher/mod.rs
+++ b/crates/accounts/src/publisher/mod.rs
@@ -1,12 +1,9 @@
 use std::sync::Arc;
 
-use rand::Rng;
+use rand::RngExt;
 
 use miden_client::{
-    account::{
-        component::{AuthScheme, AuthSingleSig},
-        Account,
-    },
+    account::{component::AuthSingleSig, Account},
     auth::AuthSecretKey,
     keystore::{FilesystemKeyStore, Keystore},
     Client, Word,
@@ -14,14 +11,12 @@ use miden_client::{
 
 use miden_protocol::{
     account::{
-        AccountBuilder, AccountComponent, AccountComponentMetadata, AccountType, StorageSlot,
-        StorageSlotName,
+        AccountBuilder, AccountComponent, AccountComponentCode, AccountComponentMetadata,
+        AccountType, StorageSlot, StorageSlotName,
     },
-    assembly::{DefaultSourceManager, Library, Module, ModuleKind, Path as LibraryPath},
-    transaction::TransactionKernel,
+    assembly::Package,
 };
-
-use miden_protocol::assembly::mast::MastNodeExt;
+use miden_standards::code_builder::CodeBuilder;
 
 pub const PUBLISHER_ACCOUNT_MASM: &str = include_str!("publisher.masm");
 
@@ -29,21 +24,9 @@ pub const PUBLISHER_ACCOUNT_MASM: &str = include_str!("publisher.masm");
 /// This is used by the oracle to call the publisher's get_entry procedure.
 pub fn get_entry_procedure_hash() -> String {
     let lib = get_publisher_component_library();
-    let export = lib
-        .exports()
-        .find(|e| {
-            let path = e.path();
-            let path_str = path.as_ref().as_str();
-            path_str.ends_with("::get_entry") || path_str == "get_entry"
-        })
-        .expect("get_entry procedure not found in publisher library");
-
-    let node_id = lib.get_export_node_id(export.path());
     let digest = lib
-        .mast_forest()
-        .get_node_by_id(node_id)
-        .expect("node not found")
-        .digest();
+        .get_procedure_root_by_path(format!("{PUBLISHER_MODULE_PATH}::get_entry").as_str())
+        .expect("get_entry procedure not found in publisher library");
 
     digest
         .as_elements()
@@ -54,28 +37,26 @@ pub fn get_entry_procedure_hash() -> String {
         .join(".")
 }
 
-pub fn get_publisher_component_library() -> Arc<Library> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let publisher_component_module = Module::parser(ModuleKind::Library)
-        .parse_str(
-            LibraryPath::new("publisher_component::publisher_module"),
-            PUBLISHER_ACCOUNT_MASM,
-            source_manager.clone(),
-        )
-        .unwrap();
+pub const PUBLISHER_MODULE_PATH: &str = "publisher_component::publisher_module";
 
-    TransactionKernel::assembler_with_source_manager(source_manager)
-        .assemble_library([publisher_component_module])
+/// Compiles the publisher MASM into an account component code (0.16: components
+/// are MAST packages assembled against the transaction kernel).
+pub fn get_publisher_component_code() -> AccountComponentCode {
+    CodeBuilder::new()
+        .compile_component_code(PUBLISHER_MODULE_PATH, PUBLISHER_ACCOUNT_MASM)
         .expect("assembly should succeed")
 }
 
+pub fn get_publisher_component_library() -> Arc<Package> {
+    Arc::new(get_publisher_component_code().into_package())
+}
+
 pub fn get_publisher_component() -> AccountComponent {
-    let library = get_publisher_component_library();
-    let library = Arc::try_unwrap(library).unwrap_or_else(|arc| (*arc).clone());
     let storage_slot =
         StorageSlot::with_empty_map(StorageSlotName::new("pragma::publisher::entries").unwrap());
     let metadata = AccountComponentMetadata::new("pragma::publisher");
-    AccountComponent::new(library, vec![storage_slot], metadata).expect("assembly should succeed")
+    AccountComponent::new(get_publisher_component_code(), vec![storage_slot], metadata)
+        .expect("assembly should succeed")
 }
 
 pub struct PublisherAccountBuilder<'a> {
@@ -125,16 +106,13 @@ impl<'a> PublisherAccountBuilder<'a> {
         // ECDSA (secp256k1/keccak) auth: far fewer VM cycles than Falcon512 to
         // verify in-circuit, which directly shrinks the publish tx proof.
         let auth_key = AuthSecretKey::new_ecdsa_k256_keccak();
-        let auth_component = AuthSingleSig::new(
-            auth_key.public_key().to_commitment(),
-            AuthScheme::EcdsaK256Keccak,
-        );
+        let auth_component = AuthSingleSig::from_public_key(auth_key.public_key());
 
         let publisher_component: AccountComponent = get_publisher_component();
         let from_seed = client.rng().random();
         let account = AccountBuilder::new(from_seed)
             .account_type(self.account_type)
-            .with_auth_component(auth_component)
+            .with_component(auth_component)
             .with_component(publisher_component)
             .build()
             .unwrap();

--- a/crates/accounts/src/publisher/publisher.masm
+++ b/crates/accounts/src/publisher/publisher.masm
@@ -16,6 +16,7 @@ const ENTRIES_MAP_SLOT=word("pragma::publisher::entries")
 #! Inputs:  [faucet_id_word, ENTRY]
 #! Outputs: []
 #!
+@account_procedure
 pub proc publish_entry
     push.ENTRIES_MAP_SLOT[0..2] exec.native_account::set_map_item
     # Truncate just in case
@@ -27,6 +28,7 @@ end
 #! Inputs:  [faucet_id_word]
 #! Outputs: [ENTRY] ; Word being [faucet_id_prefix, price, decimals, timestamp]
 #!
+@account_procedure
 pub proc get_entry
     push.ENTRIES_MAP_SLOT[0..2]
 

--- a/crates/accounts/tests/test_oracle.rs
+++ b/crates/accounts/tests/test_oracle.rs
@@ -21,7 +21,7 @@ use miden_testing::{assert_transaction_executor_error, Auth, MockChain, MockChai
 
 use pm_accounts::{
     oracle::{get_oracle_component, get_oracle_component_library},
-    publisher::{get_publisher_component, get_publisher_component_library},
+    publisher::{get_publisher_component, get_publisher_component_code},
     utils::word_to_masm,
 };
 use pm_types::{Currency, Entry, Pair};
@@ -45,13 +45,12 @@ fn falcon_auth() -> Auth {
 /// `(pair, entry)` pair, so FPI from the oracle sees the price without
 /// needing the publisher to run a separate publish_entry tx.
 fn publisher_component_with_entry(pair: Word, entry: Word) -> AccountComponent {
-    let library = (*get_publisher_component_library()).clone();
     let storage_slot = StorageSlot::with_map(
         StorageSlotName::new("pragma::publisher::entries").unwrap(),
         StorageMap::with_entries(vec![(StorageMapKey::new(pair), entry)]).unwrap(),
     );
     let metadata = AccountComponentMetadata::new("pragma::publisher");
-    AccountComponent::new(library, vec![storage_slot], metadata)
+    AccountComponent::new(get_publisher_component_code(), vec![storage_slot], metadata)
         .expect("publisher component should assemble")
 }
 
@@ -61,7 +60,8 @@ fn register_publisher_script(publisher_id: AccountId) -> Result<TransactionScrip
         use oracle_component::oracle_module
         use miden::core::sys
 
-        begin
+        @transaction_script
+        pub proc main
             push.0.0
             push.{suffix} push.{prefix}
             call.oracle_module::register_publisher
@@ -72,7 +72,7 @@ fn register_publisher_script(publisher_id: AccountId) -> Result<TransactionScrip
         suffix = publisher_id.suffix(),
     );
     Ok(CodeBuilder::default()
-        .with_statically_linked_library(&get_oracle_component_library())?
+        .with_statically_linked_package(&get_oracle_component_library())?
         .compile_tx_script(tx_script_code)?)
 }
 
@@ -82,7 +82,8 @@ fn remove_publisher_script(publisher_id: AccountId) -> Result<TransactionScript>
         use oracle_component::oracle_module
         use miden::core::sys
 
-        begin
+        @transaction_script
+        pub proc main
             push.0.0
             push.{suffix} push.{prefix}
             call.oracle_module::remove_publisher
@@ -93,7 +94,7 @@ fn remove_publisher_script(publisher_id: AccountId) -> Result<TransactionScript>
         suffix = publisher_id.suffix(),
     );
     Ok(CodeBuilder::default()
-        .with_statically_linked_library(&get_oracle_component_library())?
+        .with_statically_linked_package(&get_oracle_component_library())?
         .compile_tx_script(tx_script_code)?)
 }
 
@@ -103,7 +104,8 @@ fn get_median_script(pair_word: Word) -> Result<TransactionScript> {
         use oracle_component::oracle_module
         use miden::core::sys
 
-        begin
+        @transaction_script
+        pub proc main
             push.{pair}
             call.oracle_module::get_median
             exec.sys::truncate_stack
@@ -112,7 +114,7 @@ fn get_median_script(pair_word: Word) -> Result<TransactionScript> {
         pair = word_to_masm(pair_word),
     );
     Ok(CodeBuilder::default()
-        .with_statically_linked_library(&get_oracle_component_library())?
+        .with_statically_linked_package(&get_oracle_component_library())?
         .compile_tx_script(tx_script_code)?)
 }
 
@@ -148,61 +150,54 @@ fn onchain_faucet_key(prefix: u64, suffix: u64) -> Word {
     .into()
 }
 
-/// Resolves an oracle-component procedure to its MAST root so it can be invoked
-/// by digest under `execute_code` — which assembles with mock libraries only
-/// and therefore can't resolve `use oracle_component::oracle_module`.
-fn oracle_proc_root(name: &str) -> Word {
-    let lib = get_oracle_component_library();
-    let short = format!("oracle_module::{name}");
-    let full = format!("oracle_component::oracle_module::{name}");
-    lib.get_procedure_root_by_path(short.as_str())
-        .or_else(|| lib.get_procedure_root_by_path(full.as_str()))
-        .expect("oracle procedure root must resolve")
-}
-
-/// Runs `get_median` for a faucet via `execute_code` (call-by-MAST-root) and
-/// returns the readable output stack `(is_tracked, median_price, amount)`.
-/// Unlike `execute()`, `execute_code` exposes the final operand stack.
-async fn run_get_median(
+/// Runs `get_median` for a faucet inside a real mock transaction and asserts
+/// the returned `(is_tracked, median_price)` in-script: 0.16 no longer exposes
+/// the operand stack of an executed transaction, so the expected values are
+/// baked into the tx script and a mismatch fails the execution.
+async fn assert_get_median(
     mock_chain: &MockChain,
     oracle_id: AccountId,
     publisher_ids: &[AccountId],
     faucet_prefix: u64,
     faucet_suffix: u64,
-) -> Result<(u64, u64, u64)> {
+    expected_is_tracked: u64,
+    expected_median: u64,
+) -> Result<()> {
     let foreign_inputs = publisher_ids
         .iter()
         .map(|id| mock_chain.get_foreign_account_inputs(*id))
         .collect::<anyhow::Result<Vec<_>>>()?;
-    let ctx = mock_chain
-        .build_tx_context(oracle_id, &[], &[])?
-        .foreign_accounts(foreign_inputs)
-        .build()?;
-    let code = format!(
+    let tx_script_code = format!(
         "
-        use $kernel::prologue
+        use oracle_component::oracle_module
         use miden::core::sys
 
-        begin
-            exec.prologue::prepare_transaction
+        @transaction_script
+        pub proc main
             push.0.0.{suffix}.{prefix}
-            call.{root}
+            call.oracle_module::get_median
+            # => [is_tracked, median_price, amount, ...]
+            push.{expected_is_tracked} assert_eq.err=\"unexpected is_tracked\"
+            push.{expected_median} assert_eq.err=\"unexpected median\"
+            drop
             exec.sys::truncate_stack
         end
         ",
         prefix = faucet_prefix,
         suffix = faucet_suffix,
-        root = oracle_proc_root("get_median").to_hex(),
     );
-    let out = ctx
-        .execute_code(&code)
+    let script = CodeBuilder::default()
+        .with_statically_linked_package(&get_oracle_component_library())?
+        .compile_tx_script(tx_script_code)?;
+    mock_chain
+        .build_transaction(oracle_id)
+        .foreign_accounts(foreign_inputs)
+        .tx_script(script)
+        .build()?
+        .execute()
         .await
-        .map_err(|e| anyhow::anyhow!("get_median execute_code failed: {e:?}"))?;
-    Ok((
-        out.stack[0].as_canonical_u64(),
-        out.stack[1].as_canonical_u64(),
-        out.stack[2].as_canonical_u64(),
-    ))
+        .map_err(|e| anyhow::anyhow!("get_median failed: {e:?}"))?;
+    Ok(())
 }
 
 // ============================================================================
@@ -221,13 +216,13 @@ async fn test_oracle_register_publisher() -> Result<()> {
     let publisher_id = publisher.id();
 
     let tx_context = mock_chain
-        .build_tx_context(oracle.id(), &[], &[])?
+        .build_transaction(oracle.id())
         .tx_script(register_publisher_script(publisher_id)?)
         .build()?;
     let executed_tx = tx_context.execute().await?;
 
     let mut oracle = oracle.clone();
-    oracle.apply_delta(executed_tx.account_delta())?;
+    oracle.apply_patch(executed_tx.account_patch())?;
 
     let next_index_slot = StorageSlotName::new("pragma::oracle::next_publisher_index").unwrap();
     assert_eq!(
@@ -240,7 +235,7 @@ async fn test_oracle_register_publisher() -> Result<()> {
     let slot_key: Word = [Felt::new(2).unwrap(), ZERO, ZERO, ZERO].into();
     let stored = oracle
         .storage()
-        .get_map_item(&publishers_slot, slot_key)
+        .get_map_item(&publishers_slot, StorageMapKey::new(slot_key))
         .unwrap();
     assert_eq!(
         stored,
@@ -270,7 +265,7 @@ async fn test_oracle_register_publisher_fails_if_already_registered() -> Result<
 
     // First registration: succeed and commit so the next tx sees the new state.
     let first_tx = mock_chain
-        .build_tx_context(oracle.id(), &[], &[])?
+        .build_transaction(oracle.id())
         .tx_script(register_publisher_script(publisher_id)?)
         .build()?;
     let first_executed = first_tx.execute().await?;
@@ -279,7 +274,7 @@ async fn test_oracle_register_publisher_fails_if_already_registered() -> Result<
 
     // Second registration: must fail with ERR_PUBLISHER_ALREADY_REGISTERED.
     let second_tx = mock_chain
-        .build_tx_context(oracle.id(), &[], &[])?
+        .build_transaction(oracle.id())
         .tx_script(register_publisher_script(publisher_id)?)
         .build()?;
     let result = second_tx.execute().await;
@@ -306,7 +301,7 @@ async fn test_oracle_remove_publisher() -> Result<()> {
 
     // Register first.
     let register_tx = mock_chain
-        .build_tx_context(oracle.id(), &[], &[])?
+        .build_transaction(oracle.id())
         .tx_script(register_publisher_script(publisher_id)?)
         .build()?;
     let register_executed = register_tx.execute().await?;
@@ -315,13 +310,13 @@ async fn test_oracle_remove_publisher() -> Result<()> {
 
     // Now remove.
     let remove_tx = mock_chain
-        .build_tx_context(oracle.id(), &[], &[])?
+        .build_transaction(oracle.id())
         .tx_script(remove_publisher_script(publisher_id)?)
         .build()?;
     let remove_executed = remove_tx.execute().await?;
 
     let mut oracle = mock_chain.committed_account(oracle.id())?.clone();
-    oracle.apply_delta(remove_executed.account_delta())?;
+    oracle.apply_patch(remove_executed.account_patch())?;
 
     let next_index_slot = StorageSlotName::new("pragma::oracle::next_publisher_index").unwrap();
     assert_eq!(
@@ -334,7 +329,7 @@ async fn test_oracle_remove_publisher() -> Result<()> {
     let slot_key: Word = [Felt::new(2).unwrap(), ZERO, ZERO, ZERO].into();
     let stored = oracle
         .storage()
-        .get_map_item(&publishers_slot, slot_key)
+        .get_map_item(&publishers_slot, StorageMapKey::new(slot_key))
         .unwrap();
     assert_eq!(
         stored,
@@ -357,7 +352,7 @@ async fn test_oracle_remove_publisher_fails_if_not_registered() -> Result<()> {
     let publisher_id = publisher.id();
 
     let tx_context = mock_chain
-        .build_tx_context(oracle.id(), &[], &[])?
+        .build_transaction(oracle.id())
         .tx_script(remove_publisher_script(publisher_id)?)
         .build()?;
     let result = tx_context.execute().await;
@@ -411,7 +406,7 @@ async fn test_oracle_get_median_skips_soft_deleted_publishers() -> Result<()> {
     // Register both publishers.
     for publisher_id in [publisher1.id(), publisher2.id()] {
         let tx = mock_chain
-            .build_tx_context(oracle.id(), &[], &[])?
+            .build_transaction(oracle.id())
             .tx_script(register_publisher_script(publisher_id)?)
             .build()?;
         let executed = tx.execute().await?;
@@ -421,7 +416,7 @@ async fn test_oracle_get_median_skips_soft_deleted_publishers() -> Result<()> {
 
     // Soft-delete publisher1.
     let remove_tx = mock_chain
-        .build_tx_context(oracle.id(), &[], &[])?
+        .build_transaction(oracle.id())
         .tx_script(remove_publisher_script(publisher1.id())?)
         .build()?;
     let remove_executed = remove_tx.execute().await?;
@@ -433,7 +428,7 @@ async fn test_oracle_get_median_skips_soft_deleted_publishers() -> Result<()> {
     // (the zeroed publisher1 slot) and fail.
     let foreign_inputs = vec![mock_chain.get_foreign_account_inputs(publisher2.id())?];
     let tx_context = mock_chain
-        .build_tx_context(oracle.id(), &[], &[])?
+        .build_transaction(oracle.id())
         .foreign_accounts(foreign_inputs)
         .tx_script(get_median_script(pair_word)?)
         .build()?;
@@ -480,7 +475,7 @@ async fn test_oracle_get_median_value() -> Result<()> {
     // Register both publishers, then advance the chain so the get_median block
     // timestamp matches the entries (age 0 < MAX_ENTRY_AGE_SECONDS).
     let tx = mock_chain
-        .build_tx_context(oracle.id(), &[], &[])?
+        .build_transaction(oracle.id())
         .tx_script(register_publisher_script(pub_a.id())?)
         .build()?;
     let ex = tx.execute().await?;
@@ -488,7 +483,7 @@ async fn test_oracle_get_median_value() -> Result<()> {
     mock_chain.prove_next_block()?;
 
     let tx = mock_chain
-        .build_tx_context(oracle.id(), &[], &[])?
+        .build_transaction(oracle.id())
         .tx_script(register_publisher_script(pub_b.id())?)
         .build()?;
     let ex = tx.execute().await?;
@@ -496,27 +491,38 @@ async fn test_oracle_get_median_value() -> Result<()> {
     mock_chain.prove_next_block_at(FRESH_TS)?;
 
     // Median over both publishers = average of 50_000 and 52_000.
-    let (is_tracked, median, _amount) =
-        run_get_median(&mock_chain, oracle.id(), &[pub_a.id(), pub_b.id()], 1, 0).await?;
-    assert_eq!(is_tracked, 1, "pair must be tracked");
-    assert_eq!(median, 51_000_000_000, "median = avg(50_000, 52_000)");
+    assert_get_median(
+        &mock_chain,
+        oracle.id(),
+        &[pub_a.id(), pub_b.id()],
+        1,
+        0,
+        1,
+        51_000_000_000,
+    )
+    .await
+    .context("median = avg(50_000, 52_000)")?;
 
     // Soft-delete pub_a; the median must drop to pub_b's price alone.
     let rm = mock_chain
-        .build_tx_context(oracle.id(), &[], &[])?
+        .build_transaction(oracle.id())
         .tx_script(remove_publisher_script(pub_a.id())?)
         .build()?;
     let rm_ex = rm.execute().await?;
     mock_chain.add_pending_executed_transaction(&rm_ex)?;
     mock_chain.prove_next_block_at(FRESH_TS + 100)?;
 
-    let (is_tracked, median, _amount) =
-        run_get_median(&mock_chain, oracle.id(), &[pub_b.id()], 1, 0).await?;
-    assert_eq!(is_tracked, 1);
-    assert_eq!(
-        median, 52_000_000_000,
-        "after soft-delete, median = pub_b price only"
-    );
+    assert_get_median(
+        &mock_chain,
+        oracle.id(),
+        &[pub_b.id()],
+        1,
+        0,
+        1,
+        52_000_000_000,
+    )
+    .await
+    .context("after soft-delete, median = pub_b price only")?;
 
     Ok(())
 }
@@ -551,7 +557,7 @@ async fn test_oracle_get_median_skips_stale_entry() -> Result<()> {
 
     for id in [stale_pub.id(), fresh_pub.id()] {
         let tx = mock_chain
-            .build_tx_context(oracle.id(), &[], &[])?
+            .build_transaction(oracle.id())
             .tx_script(register_publisher_script(id)?)
             .build()?;
         let ex = tx.execute().await?;
@@ -561,19 +567,17 @@ async fn test_oracle_get_median_skips_stale_entry() -> Result<()> {
     mock_chain.prove_next_block_at(NOW_TS)?;
 
     // The stale entry is dropped → median = fresh price only, not the average.
-    let (is_tracked, median, _amount) = run_get_median(
+    assert_get_median(
         &mock_chain,
         oracle.id(),
         &[stale_pub.id(), fresh_pub.id()],
         1,
         0,
+        1,
+        52_000_000_000,
     )
-    .await?;
-    assert_eq!(is_tracked, 1);
-    assert_eq!(
-        median, 52_000_000_000,
-        "stale entry skipped; median = fresh price only"
-    );
+    .await
+    .context("stale entry skipped; median = fresh price only")?;
 
     Ok(())
 }

--- a/crates/cli/oracle/src/commands/get_entry.rs
+++ b/crates/cli/oracle/src/commands/get_entry.rs
@@ -86,7 +86,8 @@ impl GetEntryCmd {
             use oracle_component::oracle_module
             use miden::core::sys
 
-            begin
+            @transaction_script
+            pub proc main
                 push.{faucet_id}
                 push.0.0
                 push.{account_id_suffix} push.{account_id_prefix}
@@ -101,7 +102,7 @@ impl GetEntryCmd {
 
         let oracle_lib = get_oracle_component_library();
         let get_entry_script = CodeBuilder::default()
-            .with_dynamically_linked_library(&oracle_lib)
+            .with_dynamically_linked_package(&*oracle_lib)
             .map_err(|e| anyhow::anyhow!("Error while setting up the component library: {e:?}"))?
             .compile_tx_script(tx_script_code)
             .map_err(|e| anyhow::anyhow!("Error while compiling the script: {e:?}"))?;

--- a/crates/cli/oracle/src/commands/median.rs
+++ b/crates/cli/oracle/src/commands/median.rs
@@ -84,7 +84,7 @@ impl MedianCmd {
             .map(|i: u64| -> anyhow::Result<Word> {
                 let key: [Felt; 4] = [Felt::new(i)?, ZERO, ZERO, ZERO];
                 storage
-                    .get_map_item(&publishers_slot, key.into())
+                    .get_map_item(&publishers_slot, StorageMapKey::new(key.into()))
                     .with_context(|| format!("Failed to retrieve publisher at index {i}"))
             })
             .collect::<Result<Vec<_>, _>>()?
@@ -117,7 +117,8 @@ impl MedianCmd {
             use oracle_component::oracle_module
             use miden::core::sys
     
-            begin
+            @transaction_script
+            pub proc main
                 push.0.{amount}.{suffix}.{prefix}
                 call.oracle_module::get_median
                 exec.sys::truncate_stack
@@ -129,7 +130,7 @@ impl MedianCmd {
         );
         let oracle_lib = get_oracle_component_library();
         let median_script = CodeBuilder::default()
-            .with_dynamically_linked_library(&oracle_lib)
+            .with_dynamically_linked_package(&*oracle_lib)
             .map_err(|e| anyhow::anyhow!("Error while setting up the component library: {e:?}"))?
             .compile_tx_script(tx_script_code.clone())
             .map_err(|e| anyhow::anyhow!("Error while compiling the script: {e:?}"))?;

--- a/crates/cli/oracle/src/commands/median_batch.rs
+++ b/crates/cli/oracle/src/commands/median_batch.rs
@@ -103,7 +103,7 @@ impl MedianBatchCmd {
             .map(|i| -> anyhow::Result<Word> {
                 let key: [Felt; 4] = [Felt::new(i)?, ZERO, ZERO, ZERO];
                 storage
-                    .get_map_item(&publishers_slot, key.into())
+                    .get_map_item(&publishers_slot, StorageMapKey::new(key.into()))
                     .with_context(|| format!("Failed to retrieve publisher at index {i}"))
             })
             .collect::<Result<Vec<_>, _>>()
@@ -159,7 +159,8 @@ impl MedianBatchCmd {
                 use oracle_component::oracle_module
                 use miden::core::sys
         
-                begin
+                @transaction_script
+                pub proc main
                     push.0.0.{suffix}.{prefix}
                     call.oracle_module::get_median
                     exec.sys::truncate_stack
@@ -171,7 +172,7 @@ impl MedianBatchCmd {
 
             let oracle_lib = get_oracle_component_library();
             let median_script = CodeBuilder::default()
-                .with_dynamically_linked_library(&oracle_lib)
+                .with_dynamically_linked_package(&*oracle_lib)
                 .map_err(|e| {
                     anyhow::anyhow!("Error while setting up the component library: {e:?}")
                 })?

--- a/crates/cli/oracle/src/commands/publishers.rs
+++ b/crates/cli/oracle/src/commands/publishers.rs
@@ -1,3 +1,4 @@
+use miden_protocol::account::StorageMapKey;
 use std::path::Path;
 
 use anyhow::Context;
@@ -81,7 +82,7 @@ impl PublishersCmd {
             // MASM stack has idx at bottom of KEY word, so word[0]=idx
             let key: [Felt; 4] = [Felt::new(i)?, ZERO, ZERO, ZERO];
             let publisher_word = storage
-                .get_map_item(&publishers_slot, key.into())
+                .get_map_item(&publishers_slot, StorageMapKey::new(key.into()))
                 .with_context(|| format!("Failed to retrieve publisher at index {i}"))?;
             // In 0.14 LE, publisher ID word is [prefix, suffix, 0, 0]
             // (matches median.rs and the on-chain storage layout).

--- a/crates/cli/oracle/src/commands/register_publisher.rs
+++ b/crates/cli/oracle/src/commands/register_publisher.rs
@@ -60,7 +60,8 @@ impl RegisterPublisherCmd {
             "
             use oracle_component::oracle_module
             use miden::core::sys
-            begin
+            @transaction_script
+            pub proc main
                 push.0.0
                 push.{account_id_suffix} push.{account_id_prefix}
                 call.oracle_module::register_publisher
@@ -72,7 +73,7 @@ impl RegisterPublisherCmd {
         );
         let oracle_lib = get_oracle_component_library();
         let register_script = CodeBuilder::default()
-            .with_dynamically_linked_library(&oracle_lib)
+            .with_dynamically_linked_package(&*oracle_lib)
             .map_err(|e| anyhow::anyhow!("Error while setting up the component library: {e:?}"))?
             .compile_tx_script(tx_script_code)
             .map_err(|e| anyhow::anyhow!("Error while compiling the script: {e:?}"))?;

--- a/crates/cli/oracle/src/commands/remove_publisher.rs
+++ b/crates/cli/oracle/src/commands/remove_publisher.rs
@@ -33,7 +33,8 @@ impl RemovePublisherCmd {
             "
             use oracle_component::oracle_module
             use miden::core::sys
-            begin
+            @transaction_script
+            pub proc main
                 push.0.0
                 push.{account_id_suffix} push.{account_id_prefix}
                 call.oracle_module::remove_publisher
@@ -45,7 +46,7 @@ impl RemovePublisherCmd {
         );
         let oracle_lib = get_oracle_component_library();
         let remove_script = CodeBuilder::default()
-            .with_dynamically_linked_library(&oracle_lib)
+            .with_dynamically_linked_package(&*oracle_lib)
             .map_err(|e| anyhow::anyhow!("Error while setting up the component library: {e:?}"))?
             .compile_tx_script(tx_script_code)
             .map_err(|e| anyhow::anyhow!("Error while compiling the script: {e:?}"))?;

--- a/crates/cli/publisher/pyproject.toml
+++ b/crates/cli/publisher/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "pm-publisher"
-version = "0.1.0-alpha.10"
+version = "0.1.0-alpha.11"
 description = "Python bindings for Pragma Miden Publisher CLI"
 authors = [{ name = "Pragma", email = "jordy@pragma.build" }]
 requires-python = ">=3.7"

--- a/crates/cli/publisher/src/commands/entry.rs
+++ b/crates/cli/publisher/src/commands/entry.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use miden_client::{keystore::FilesystemKeyStore, Client};
+use miden_protocol::account::StorageMapKey;
 use pm_types::Entry;
 use pm_utils_cli::{get_publisher_id, PRAGMA_ACCOUNTS_STORAGE_FILE};
 use prettytable::{Cell, Row, Table};
@@ -55,7 +56,7 @@ impl EntryCmd {
                 .map_err(|e| anyhow::anyhow!("Invalid storage slot name: {e:?}"))?;
         let entry_word = publisher
             .storage()
-            .get_map_item(&publisher_entries_slot, faucet_id_word)
+            .get_map_item(&publisher_entries_slot, StorageMapKey::new(faucet_id_word))
             .unwrap();
         let mut entry = Entry::from(entry_word);
         entry.faucet_id = self.faucet_id.clone();

--- a/crates/cli/publisher/src/commands/get_entry.rs
+++ b/crates/cli/publisher/src/commands/get_entry.rs
@@ -78,7 +78,8 @@ impl GetEntryCmd {
             use publisher_component::publisher_module
             use miden::core::sys
     
-            begin
+            @transaction_script
+            pub proc main
                 push.{faucet_id}
 
                 call.publisher_module::get_entry
@@ -90,7 +91,7 @@ impl GetEntryCmd {
 
         let publisher_lib = get_publisher_component_library();
         let get_entry_script = CodeBuilder::default()
-            .with_statically_linked_library(&publisher_lib)
+            .with_statically_linked_package(&publisher_lib)
             .map_err(|e| anyhow::anyhow!("Error while setting up the component library: {e:?}"))?
             .compile_tx_script(tx_script_code)
             .map_err(|e| anyhow::anyhow!("Error while compiling the script: {e:?}"))?;

--- a/crates/cli/publisher/src/commands/publish.rs
+++ b/crates/cli/publisher/src/commands/publish.rs
@@ -87,7 +87,8 @@ impl PublishCmd {
                 use publisher_component::publisher_module
                 use miden::core::sys
         
-                begin
+                @transaction_script
+                pub proc main
                     push.{entry}
                     push.0.0.{suffix}.{prefix}
 
@@ -103,7 +104,7 @@ impl PublishCmd {
         );
         let publisher_lib = get_publisher_component_library();
         let publish_script = CodeBuilder::default()
-            .with_statically_linked_library(&publisher_lib)
+            .with_statically_linked_package(&publisher_lib)
             .map_err(|e| anyhow::anyhow!("Error while setting up the component library: {e:?}"))?
             .compile_tx_script(tx_script_code)
             .map_err(|e| anyhow::anyhow!("Error while compiling the script: {e:?}"))?;

--- a/crates/cli/publisher/src/commands/publish_batch.rs
+++ b/crates/cli/publisher/src/commands/publish_batch.rs
@@ -173,7 +173,8 @@ pub async fn publish_batch(
             use publisher_component::publisher_module
             use miden::core::sys
 
-            begin
+            @transaction_script
+            pub proc main
                 push.{expiration} exec.::miden::protocol::tx::update_expiration_block_delta
                 {publish_calls}
                 exec.sys::truncate_stack
@@ -185,7 +186,7 @@ pub async fn publish_batch(
 
     let publisher_lib = get_publisher_component_library();
     let publish_script = CodeBuilder::default()
-        .with_statically_linked_library(&publisher_lib)
+        .with_statically_linked_package(&publisher_lib)
         .map_err(|e| anyhow::anyhow!("Error while setting up the component library: {e:?}"))?
         .compile_tx_script(tx_script_code)
         .map_err(|e| anyhow::anyhow!("Error while compiling the script: {e:?}"))?;

--- a/crates/cli/publisher/src/lib.rs
+++ b/crates/cli/publisher/src/lib.rs
@@ -123,7 +123,9 @@ where
                 "pm-publisher: Miden store pool wedged during {label}; evicted the cached client, it will be rebuilt on the next call"
             );
         }
-        PyValueError::new_err(format!("{label} failed: {e}"))
+        // `:#` prints the whole anyhow context chain on one line, e.g.
+        // "Import account failed: RPC error: account not found ...".
+        PyValueError::new_err(format!("{label} failed: {e:#}"))
     })
 }
 
@@ -313,7 +315,10 @@ fn py_import_account(
         })?;
 
         map_cmd_err(
-            client.import_account_by_id(id).await,
+            client
+                .import_account_by_id(id)
+                .await
+                .map_err(anyhow::Error::from),
             &key,
             "Import account",
         )?;

--- a/crates/cli/utils/src/client.rs
+++ b/crates/cli/utils/src/client.rs
@@ -2,17 +2,17 @@ use crate::STORE_FILENAME;
 use miden_client::grpc_support::{DEVNET_PROVER_ENDPOINT, TESTNET_PROVER_ENDPOINT};
 use miden_client::{
     account::{
-        component::{AuthScheme, AuthSingleSig, BasicWallet},
+        component::{AuthSingleSig, BasicWallet},
         Account, AccountBuilder, AccountType,
     },
     builder::ClientBuilder,
     crypto::{rpo_falcon512::SecretKey, RandomCoin},
     keystore::{FilesystemKeyStore, Keystore},
-    rpc::{Endpoint, GrpcClient},
+    rpc::{Endpoint, GrpcClient, VerifyingRpcClient},
     Client, ClientError, Felt, RemoteTransactionProver, Word,
 };
 use miden_client_sqlite_store::SqliteStore;
-use rand::RngCore;
+use rand::Rng;
 use std::{fs, path::PathBuf, sync::Arc};
 
 // Client Setup
@@ -32,17 +32,6 @@ const RPC_TIMEOUT_MS: u64 = 60_000;
 // advance. 128 MiB gives ample headroom for any single sync page.
 const MAX_DECODING_MESSAGE_SIZE: usize = 128 * 1024 * 1024;
 
-/// Debug mode is off by default (it makes the assembler try to load MASM
-/// sources for richer traces — which logs `failed to load MASM sources` in
-/// the deployed wheel and adds execution overhead). Set `PM_MIDEN_DEBUG=1`
-/// to re-enable it for development (e.g. to get `debug.stack` output).
-fn debug_mode() -> miden_client::DebugMode {
-    match std::env::var("PM_MIDEN_DEBUG").as_deref() {
-        Ok("1") | Ok("true") | Ok("TRUE") => miden_client::DebugMode::Enabled,
-        _ => miden_client::DebugMode::Disabled,
-    }
-}
-
 /// Build a Miden client for the given network endpoint.
 ///
 /// When `prover_endpoint` is `Some`, transaction proving is delegated to
@@ -56,10 +45,13 @@ async fn setup_client(
     path: Option<PathBuf>,
     keystore_path: Option<String>,
 ) -> Result<Client<FilesystemKeyStore>, ClientError> {
-    let rpc_api = Arc::new(
+    // 0.16: node responses are verified against the request (block headers,
+    // account proofs); ClientBuilder::grpc_client does this wrap itself, but we
+    // build the GrpcClient by hand to raise the decode limit.
+    let rpc_api = Arc::new(VerifyingRpcClient::new(
         GrpcClient::new(&endpoint, RPC_TIMEOUT_MS)
             .with_max_decoding_message_size(MAX_DECODING_MESSAGE_SIZE),
-    );
+    ));
 
     let coin_seed: [u64; 4] = rand::random();
     // 0.15: Felt::new is fallible (rejects value >= field modulus). Shift right by
@@ -85,8 +77,7 @@ async fn setup_client(
         .authenticator(keystore)
         .rpc(rpc_api)
         .rng(rng)
-        .store(Arc::new(store))
-        .in_debug_mode(debug_mode());
+        .store(Arc::new(store));
 
     if let Some(prover_url) = prover_endpoint {
         builder = builder.prover(Arc::new(RemoteTransactionProver::new(
@@ -157,10 +148,7 @@ where
     let key_pair = SecretKey::with_rng(client.rng());
     let account = AccountBuilder::new(init_seed)
         .account_type(account_type)
-        .with_component(AuthSingleSig::new(
-            key_pair.public_key().to_commitment().into(),
-            AuthScheme::Falcon512Poseidon2,
-        ))
+        .with_component(AuthSingleSig::falcon512_poseidon2(key_pair.public_key()))
         .with_component(BasicWallet)
         .build()
         .unwrap();

--- a/crates/cli/utils/src/lib.rs
+++ b/crates/cli/utils/src/lib.rs
@@ -1,3 +1,7 @@
+// miden-client 0.16's ClientError is large; boxing it would only move the cost
+// to every caller of the setup_* helpers.
+#![allow(clippy::result_large_err)]
+
 pub mod client;
 pub mod constants;
 pub mod network;

--- a/examples/consume-price/src/main.rs
+++ b/examples/consume-price/src/main.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
         .map(|i| -> Result<AccountId> {
             let key: Word = [Felt::new(i)?, ZERO, ZERO, ZERO].into();
             let w = storage
-                .get_map_item(&publishers_slot, key)
+                .get_map_item(&publishers_slot, StorageMapKey::new(key))
                 .with_context(|| format!("publisher at index {i} not found"))?;
             // Same layout as pm-oracle-cli: [prefix, suffix, 0, 0]
             Ok(AccountId::new_unchecked([w[0], w[1]]))
@@ -95,7 +95,8 @@ async fn main() -> Result<()> {
         use oracle_component::oracle_module
         use miden::core::sys
 
-        begin
+        @transaction_script
+        pub proc main
             push.0.0.{suffix}.{prefix}
             call.oracle_module::get_median
             exec.sys::truncate_stack
@@ -107,7 +108,7 @@ async fn main() -> Result<()> {
 
     let oracle_lib = get_oracle_component_library();
     let script = CodeBuilder::default()
-        .with_dynamically_linked_library(&oracle_lib)
+        .with_dynamically_linked_package(&*oracle_lib)
         .map_err(|e| anyhow::anyhow!("library error: {e:?}"))?
         .compile_tx_script(script_code)
         .map_err(|e| anyhow::anyhow!("compile error: {e:?}"))?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.93"
+channel = "1.98"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
## Why

The public Miden testnet moved to node **0.16** on 2026-09-09 ~05:43 UTC. It rejects 0.15 clients (`AcceptHeaderError(NoSupportedMediaRange { client_version: "0.15.3" })`), so every `publish_batch` from the price-pusher has failed since (`MIDEN: published 0/14`). The chain was also **reset**: the prod oracle `0x7ad4aa02…0c28` and publisher `0x6d37b2d4…67e3` no longer exist (`account … not found at block 92292`).

## What

- Dependencies: miden-client / protocol / tx / standards / testing **0.16**, sqlite-store 0.16, assembly / core / crypto **0.29**, rand 0.10. `miden-remote-prover-client` is gone (remote proving is built into the client).
- MSRV **1.98** (`rust-toolchain.toml`); `publish-pypi.yml` installs the pinned toolchain instead of `nightly-2025-03-11`.
- Account components are MAST packages: MASM compiled through `CodeBuilder::compile_component_code`, `Library` → `Package`, `*_linked_library` → `*_linked_package`, procedure roots via `get_procedure_root_by_path`.
- MASM: component procedures carry `@account_procedure`; every transaction script is `@transaction_script pub proc main … end` (13 inline scripts + 2 components).
- Auth: `AuthSingleSig::falcon512_poseidon2` / `from_public_key`, auth passed through `with_component`.
- `StorageMapKey::new`, `Account::apply_patch`, `MockChain::build_transaction`, `VerifyingRpcClient` around the hand-built `GrpcClient`, no `DebugMode` (and no `PM_MIDEN_DEBUG`), rand 0.10 traits.
- Oracle tests: 0.16 no longer exposes the executed transaction's operand stack, so `get_median` values are asserted in-script (`assert_eq.err=…`), same coverage.
- `pm-publisher` errors carry the whole anyhow chain; `pm-publisher` bumped to **0.1.0-alpha.11**.

## Verification

- `cargo test --workspace`: 27 passed (incl. the 7 oracle MockChain tests), `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt --check`.
- Wheel `0.1.0a11` built locally: `pm_publisher.sync(network="testnet")` succeeds against the live node (block 92253, 0.2 s); `import_account` of the prod ids returns the node's `not found at block …`.

## Not in this PR (ops, after merge)

1. Tag `py-v0.1.11` → PyPI; pragma-sdk pin `pm-publisher>=0.1.0a11`, relock, release; devops bump.
2. Re-create the oracle and publisher on the new testnet (`pm-oracle-cli init`, `pm-publisher init`, `register-publisher`), write the new ids into the `pragma_miden.json` secret / `--miden-oracle-id`, wipe the pod's Miden store, update the explorer addresses (as #68/#69 did for 0.15).
3. Devnet is on `0.16.0-rc.5` and rejects release 0.16.x clients; only testnet and local work with this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fhx2WEDuWHDrpo8ZLtZRbo
